### PR TITLE
feat(docker): restore cli_wallet to build and runtime image

### DIFF
--- a/share/vizd/docker/Dockerfile-production
+++ b/share/vizd/docker/Dockerfile-production
@@ -82,13 +82,14 @@ COPY thirdparty $APPDIR/thirdparty
 COPY plugins $APPDIR/plugins
 COPY libraries $APPDIR/libraries
 
-# Build vizd. The named cache mount `viz-ccache` is shared across all VIZ
-# Dockerfiles so that production and testnet builds in the same workflow
-# benefit from each other's compiled-object cache. `make -j$(nproc) vizd`
-# (instead of unscoped `make`) skips cli_wallet, util programs, and tests
-# that are not installed into the production image. `sharing=locked` is
-# required because ccache is not concurrent-safe; `shared` would risk cache
-# corruption under any future matrix-build setup.
+# Build vizd and cli_wallet. The named cache mount `viz-ccache` is shared across
+# all VIZ Dockerfiles so that production and testnet builds in the same workflow
+# benefit from each other's compiled-object cache. Listing both targets explicitly
+# (instead of unscoped `make`) skips util programs, tests, and examples that are
+# not shipped in the runtime image, while still compile-checking and shipping the
+# wallet CLI that operators invoke via `docker exec`. `sharing=locked` is required
+# because ccache is not concurrent-safe; `shared` would risk cache corruption
+# under any future matrix-build setup.
 RUN --mount=type=cache,target=/root/.ccache,id=viz-ccache,sharing=locked \
     cd $APPDIR && \
     git submodule update --init --recursive -f && \
@@ -103,23 +104,25 @@ RUN --mount=type=cache,target=/root/.ccache,id=viz-ccache,sharing=locked \
         -DENABLE_MONGO_PLUGIN=FALSE \
         .. \
     && \
-    make -j$(nproc) vizd && \
+    make -j$(nproc) vizd cli_wallet && \
     ccache -s
 
 # `make install` would re-trigger the `all` target through CMake's install-depends-on-all
-# rule, rebuilding cli_wallet, util programs, tests, and examples that were deliberately
-# skipped by `make -j$(nproc) vizd` above. The runtime image only invokes
-# /usr/local/bin/vizd (see share/vizd/vizd.sh), so we copy the single binary directly.
+# rule, rebuilding util programs, tests, and examples that were deliberately skipped
+# by the scoped `make` above. We copy the two binaries we ship directly instead.
 # `rm -rf $APPDIR` is unnecessary because the builder stage is discarded in multi-stage.
 RUN set -xe ;\
-    cp $APPDIR/build/programs/vizd/vizd /usr/local/bin/vizd
+    cp $APPDIR/build/programs/vizd/vizd /usr/local/bin/vizd ;\
+    cp $APPDIR/build/programs/cli_wallet/cli_wallet /usr/local/bin/cli_wallet
 
 FROM phusion/baseimage:noble-1.0.3 AS production
-# Only the daemon binary is needed at runtime (see share/vizd/vizd.sh). Static link
-# (-DBUILD_SHARED_LIBRARIES=FALSE) means no .so dependencies to ship. Copying just
-# the binary instead of the entire builder /usr/local shrinks the runtime image and
-# the layer graph exported to the GHA layer cache.
+# Two binaries are shipped: vizd (the daemon, started by share/vizd/vizd.sh) and
+# cli_wallet (invoked manually via `docker exec` for wallet operations). Static link
+# (-DBUILD_SHARED_LIBRARIES=FALSE) means no .so dependencies beyond the base image's
+# system libs. Copying just the binaries instead of the entire builder /usr/local
+# shrinks the runtime image and the layer graph exported to the GHA layer cache.
 COPY --from=builder /usr/local/bin/vizd /usr/local/bin/vizd
+COPY --from=builder /usr/local/bin/cli_wallet /usr/local/bin/cli_wallet
 
 RUN set -xe ;\
     useradd -s /bin/bash -m -d /var/lib/vizd vizd ;\

--- a/share/vizd/docker/Dockerfile-testnet
+++ b/share/vizd/docker/Dockerfile-testnet
@@ -82,13 +82,14 @@ COPY thirdparty $APPDIR/thirdparty
 COPY plugins $APPDIR/plugins
 COPY libraries $APPDIR/libraries
 
-# Build vizd. The named cache mount `viz-ccache` is shared across all VIZ
-# Dockerfiles so that production and testnet builds in the same workflow
-# benefit from each other's compiled-object cache. `make -j$(nproc) vizd`
-# (instead of unscoped `make`) skips cli_wallet, util programs, and tests
-# that are not installed into the final image. `sharing=locked` is
-# required because ccache is not concurrent-safe; `shared` would risk cache
-# corruption under any future matrix-build setup.
+# Build vizd and cli_wallet. The named cache mount `viz-ccache` is shared across
+# all VIZ Dockerfiles so that production and testnet builds in the same workflow
+# benefit from each other's compiled-object cache. Listing both targets explicitly
+# (instead of unscoped `make`) skips util programs, tests, and examples that are
+# not shipped in the runtime image, while still compile-checking and shipping the
+# wallet CLI that operators invoke via `docker exec`. `sharing=locked` is required
+# because ccache is not concurrent-safe; `shared` would risk cache corruption
+# under any future matrix-build setup.
 RUN --mount=type=cache,target=/root/.ccache,id=viz-ccache,sharing=locked \
     cd $APPDIR && \
     git submodule update --init --recursive -f && \
@@ -104,23 +105,25 @@ RUN --mount=type=cache,target=/root/.ccache,id=viz-ccache,sharing=locked \
         -DENABLE_MONGO_PLUGIN=FALSE \
         .. \
     && \
-    make -j$(nproc) vizd && \
+    make -j$(nproc) vizd cli_wallet && \
     ccache -s
 
 # `make install` would re-trigger the `all` target through CMake's install-depends-on-all
-# rule, rebuilding cli_wallet, util programs, tests, and examples that were deliberately
-# skipped by `make -j$(nproc) vizd` above. The runtime image only invokes
-# /usr/local/bin/vizd (see share/vizd/vizd.sh), so we copy the single binary directly.
+# rule, rebuilding util programs, tests, and examples that were deliberately skipped
+# by the scoped `make` above. We copy the two binaries we ship directly instead.
 # `rm -rf $APPDIR` is unnecessary because the builder stage is discarded in multi-stage.
 RUN set -xe ;\
-    cp $APPDIR/build/programs/vizd/vizd /usr/local/bin/vizd
+    cp $APPDIR/build/programs/vizd/vizd /usr/local/bin/vizd ;\
+    cp $APPDIR/build/programs/cli_wallet/cli_wallet /usr/local/bin/cli_wallet
 
 FROM phusion/baseimage:noble-1.0.3 AS production
-# Only the daemon binary is needed at runtime (see share/vizd/vizd.sh). Static link
-# (-DBUILD_SHARED_LIBRARIES=FALSE) means no .so dependencies to ship. Copying just
-# the binary instead of the entire builder /usr/local shrinks the runtime image and
-# the layer graph exported to the GHA layer cache.
+# Two binaries are shipped: vizd (the daemon, started by share/vizd/vizd.sh) and
+# cli_wallet (invoked manually via `docker exec` for wallet operations). Static link
+# (-DBUILD_SHARED_LIBRARIES=FALSE) means no .so dependencies beyond the base image's
+# system libs. Copying just the binaries instead of the entire builder /usr/local
+# shrinks the runtime image and the layer graph exported to the GHA layer cache.
 COPY --from=builder /usr/local/bin/vizd /usr/local/bin/vizd
+COPY --from=builder /usr/local/bin/cli_wallet /usr/local/bin/cli_wallet
 
 RUN set -xe ;\
     useradd -s /bin/bash -m -d /var/lib/vizd vizd ;\


### PR DESCRIPTION
## Summary

PR #98 inadvertently dropped `cli_wallet` from the Docker images. This PR restores it.

## What broke in #98

PR #98 replaced `make install` with `cp build/programs/vizd/vizd /usr/local/bin/vizd` to skip a hidden recompile of all targets that CMake's `install` target re-triggers via its implicit dependency on `all`. That worked — but the previous flow had a useful side-effect: cli_wallet's install rule (`programs/cli_wallet/CMakeLists.txt:47`) placed it at `/usr/local/bin/cli_wallet` in the builder, and the multi-stage `COPY /usr/local /usr/local` shipped it into the runtime image.

Two consequences of removing that flow:

1. **Image content regression.** `vizblockchain/vizd:latest` and `:testnet` no longer contain `/usr/local/bin/cli_wallet`. Any `docker exec <container> cli_wallet ...` workflow operators relied on is broken on `latest` post-#98.
2. **CI coverage gap.** The scoped `make -j$(nproc) vizd` invocation doesn't compile cli_wallet at all, so a compile error inside `programs/cli_wallet/` would not fail the Docker build. CI signal on cli_wallet correctness is currently zero.

## Fix

Build both targets explicitly and copy both binaries in the final stage:

```dockerfile
make -j$(nproc) vizd cli_wallet
...
RUN cp $APPDIR/build/programs/vizd/vizd /usr/local/bin/vizd ;\
    cp $APPDIR/build/programs/cli_wallet/cli_wallet /usr/local/bin/cli_wallet
...
COPY --from=builder /usr/local/bin/vizd       /usr/local/bin/vizd
COPY --from=builder /usr/local/bin/cli_wallet /usr/local/bin/cli_wallet
```

Applied identically to `Dockerfile-production` and `Dockerfile-testnet`. Util programs, tests, and examples remain skipped (they don't ship and aren't operator-facing).

## Validation

| Check | Result |
|---|---|
| Cold build time | 14m18s (vs PR #98 cold 13m14s, +64s for cli_wallet) |
| Warm rerun time | 3m37s |
| `make` step on warm rerun | 83s (ccache hit — vs 732s cold, ~89% reduction) |
| Image size | 109.14 MB (vs `latest` 99.59 MB, +9.55 MB compressed) |
| cli_wallet binary present | ✓ `/usr/local/bin/cli_wallet` confirmed in layer L4 |
| cli_wallet ELF | ✓ ELF 64-bit PIE x86-64, BuildID present, 29.18 MB |
| cli_wallet runtime deps | Same set as vizd: `libc.so.6`, `libm.so.6`, `libgcc_s.so.1`, `libstdc++.so.6` (all in phusion noble base) |

### On the warm rerun timing (3m37s vs PR #98's 1m27s)

In PR #98 the rerun fully hit the GHA layer cache for the `RUN make` step (CACHED). Here, that step re-executed at 83s. The difference comes from BuildKit's content-hash on the build context: the same source produced a slightly different layer key on the rerun, so the layer cache missed and the RUN executed.

That's fine for our purposes — **ccache then did the heavy lifting**: the from-scratch make would be ~12 minutes, but with ccache hits on every translation unit the compile was reduced to a link pass at 83s. That's the realistic speedup PRs see anyway, since each PR's SHA produces unique layer keys and only ccache (not the layer cache) carries between PRs.

### Validation method

Image audit and ELF inspection were done against the registry (Docker Hub manifest API + targeted layer-blob extraction) rather than `docker pull`/`docker run`. Same approach as #98's validation.

- [x] Cold build succeeds
- [x] Warm build succeeds and re-uses ccache (83s for make step)
- [x] Both binaries present in final image
- [x] cli_wallet ELF format and BuildID intact
- [x] cli_wallet runtime deps satisfied by base image
- [x] Image size delta matches expected cli_wallet binary footprint

## Test plan (post-merge)

- [ ] Pull `vizblockchain/vizd:latest`, run `docker run --rm vizblockchain/vizd:latest cli_wallet --help` and confirm wallet starts
- [ ] Pull `vizblockchain/vizd:testnet`, same check

## Related

- Follows PR #97 (three-layer caching) and PR #98 (skip make install)
- Restores public surface that existed prior to PR #98 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)