### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         id: setup-buildx
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -31,7 +31,7 @@ jobs:
       # same key prefix — letting build_prod restore what build_testnet
       # just saved.
       - name: Restore BuildKit cache mounts from Actions Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-mounts
         with:
           path: cache-mount
@@ -59,7 +59,7 @@ jobs:
       # build_testnet via needs:) can reuse the ccache populated by the
       # testnet build. The two images differ only in CMake flags so most
       # compiled object files have identical ccache hashes.
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./share/vizd/docker/Dockerfile-testnet
@@ -78,14 +78,14 @@ jobs:
     needs: build_testnet
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         id: setup-buildx
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -95,7 +95,7 @@ jobs:
       # hashes). Apt content fully reusable; ccache reuse depends on how
       # -DBUILD_TESTNET propagates through the build (measured per run).
       - name: Restore BuildKit cache mounts from Actions Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-mounts
         with:
           path: cache-mount
@@ -119,7 +119,7 @@ jobs:
             }
           skip-extraction: ${{ steps.cache-mounts.outputs.cache-hit }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./share/vizd/docker/Dockerfile-production

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       # setup-buildx-action is required for advanced cache features
       # (cache-from / cache-to with type=gha and mode=max). The id: lets
       # buildkit-cache-dance below pick up the builder name.
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         id: setup-buildx
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -47,7 +47,7 @@ jobs:
       # buildkit-cache-dance binds it into the build's cache mounts and
       # extracts the post-build state for the next save.
       - name: Restore BuildKit cache mounts from Actions Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-mounts
         with:
           path: cache-mount
@@ -74,7 +74,7 @@ jobs:
       # Layer cache scope is keyed on the PR's base branch so all PRs
       # targeting master share one warm-cache pool, while PRs against
       # release branches cannot poison master's cache.
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./share/vizd/docker/Dockerfile-production

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -35,7 +35,7 @@ jobs:
 
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -46,5 +46,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -24,7 +24,7 @@ jobs:
       # 1. Checkout
       # -------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
       # -------------------------------------------------------
       - name: Cache Boost
         id: cache-boost
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\Boost
           key: boost-1.86.0-mingw-ucrt64-static-v1
@@ -98,7 +98,7 @@ jobs:
       # -------------------------------------------------------
       - name: Cache OpenSSL
         id: cache-openssl
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\OpenSSL
           key: openssl-4.0.0-mingw-ucrt64-static-v1


### PR DESCRIPTION
GitHub Actions runners are deprecating the Node 20 runtime (warning seen on the docker build job). Bumps first-party + docker actions to the latest majors that run on **Node 24**:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/setup-node | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |

All major bumps are essentially "Node 24 runtime + drop deprecated inputs/outputs". Every input these workflows actually use (`submodules`, `fetch-depth`, `context`/`file`/`push`/`tags`, `cache-from`/`cache-to`, cache `key`/`path`, buildx `name` output for the cache-dance) is stable across these majors — verified against each action's v*.0.0 release notes.

Third-party actions not flagged by the deprecation (`reproducible-containers/buildkit-cache-dance`, `peter-evans/repository-dispatch`, `softprops/action-gh-release`, `msys2/setup-msys2`) are left as-is to avoid untested bumps.

## Verification
This PR's own `docker-pr-build` run exercises the new checkout/buildx/login/cache/build-push versions end-to-end — green here confirms the bumps work.