### PR TITLE
ci: publish Boost 1.91 builder base image

### DIFF
--- a/.github/workflows/boost-base-image.yml
+++ b/.github/workflows/boost-base-image.yml
@@ -5,10 +5,7 @@ name: Build Boost base image
 on:
   workflow_dispatch:
   push:
-    # TEMP: ci/boost-base-image is listed so the 1.91 base image publishes
-    # before #132 merges. Remove this branch (leaving only master) once the
-    # tag is live.
-    branches: [master, ci/boost-base-image]
+    branches: [master]
     paths:
       - 'share/vizd/docker/Dockerfile-boost'
       - '.github/workflows/boost-base-image.yml'

--- a/.github/workflows/boost-base-image.yml
+++ b/.github/workflows/boost-base-image.yml
@@ -1,0 +1,34 @@
+name: Build Boost base image
+
+# The Boost compile is expensive and changes rarely, so it lives outside the
+# per-PR build. Triggered by hand or when the Dockerfile changes.
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'share/vizd/docker/Dockerfile-boost'
+      - '.github/workflows/boost-base-image.yml'
+
+jobs:
+  build:
+    name: Build and push vizblockchain/boost
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./share/vizd/docker/Dockerfile-boost
+          push: true
+          tags: vizblockchain/boost:1.90-noble
+          cache-from: type=gha,scope=boost-base
+          cache-to: type=gha,scope=boost-base,mode=max

--- a/.github/workflows/boost-base-image.yml
+++ b/.github/workflows/boost-base-image.yml
@@ -5,7 +5,10 @@ name: Build Boost base image
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    # TEMP: ci/boost-base-image is listed so the 1.91 base image publishes
+    # before #132 merges. Remove this branch (leaving only master) once the
+    # tag is live.
+    branches: [master, ci/boost-base-image]
     paths:
       - 'share/vizd/docker/Dockerfile-boost'
       - '.github/workflows/boost-base-image.yml'
@@ -33,6 +36,6 @@ jobs:
           # Docker Hub account can push tags to repos that already exist but
           # cannot create a new one (vizblockchain/boost). Revisit if a
           # dedicated boost repo is ever provisioned.
-          tags: vizblockchain/vizd:boost-base-1.90-noble
+          tags: vizblockchain/vizd:boost-base-1.91-noble
           cache-from: type=gha,scope=boost-base
           cache-to: type=gha,scope=boost-base,mode=max

--- a/.github/workflows/boost-base-image.yml
+++ b/.github/workflows/boost-base-image.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Build and push vizblockchain/boost
+    name: Build and push the Boost base image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,6 +29,10 @@ jobs:
           context: .
           file: ./share/vizd/docker/Dockerfile-boost
           push: true
-          tags: vizblockchain/boost:1.90-noble
+          # Stored as a tag on the existing vizblockchain/vizd repo: the CI
+          # Docker Hub account can push tags to repos that already exist but
+          # cannot create a new one (vizblockchain/boost). Revisit if a
+          # dedicated boost repo is ever provisioned.
+          tags: vizblockchain/vizd:boost-base-1.90-noble
           cache-from: type=gha,scope=boost-base
           cache-to: type=gha,scope=boost-base,mode=max

--- a/share/vizd/docker/Dockerfile-boost
+++ b/share/vizd/docker/Dockerfile-boost
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 #
-# Builder base image: phusion/baseimage:noble-1.0.3 plus Boost 1.90 built from
+# Builder base image: phusion/baseimage:noble-1.0.3 plus Boost 1.91 built from
 # source.  Noble ships Boost 1.83, and viz needs to build against 1.9x, so the
 # Boost compile lives here rather than in the per-PR build.  This image is
 # rebuilt only when this file changes.
@@ -18,8 +18,8 @@
 # noble's 3.28 only warns.
 FROM phusion/baseimage:noble-1.0.3
 
-ARG BOOST_VERSION=1.90.0
-ARG BOOST_VERSION_UNDERSCORE=1_90_0
+ARG BOOST_VERSION=1.91.0
+ARG BOOST_VERSION_UNDERSCORE=1_91_0
 
 ENV LANG=en_US.UTF-8
 
@@ -60,8 +60,13 @@ RUN set -xe ; \
         "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" && \
     tar -xzf /tmp/boost.tar.gz -C /tmp && \
     cd "/tmp/boost_${BOOST_VERSION_UNDERSCORE}" && \
+    # `system` is deliberately absent: Boost.System is header-only from 1.69 and
+    # 1.91 dropped the compiled stub entirely, so `b2` hard-errors on it as an
+    # unknown library name. Its headers still install with the tree, and the
+    # project probes for the boost_system CMake config rather than assuming it
+    # (see CMakeLists.txt), so nothing downstream needs the compiled lib.
     ./bootstrap.sh --prefix=/usr/local \
-        --with-libraries=chrono,context,coroutine,date_time,filesystem,iostreams,locale,program_options,serialization,system,test,thread && \
+        --with-libraries=chrono,context,coroutine,date_time,filesystem,iostreams,locale,program_options,serialization,test,thread && \
     ./b2 -j"$(nproc)" \
         variant=release \
         link=static \
@@ -73,5 +78,5 @@ RUN set -xe ; \
 
 # Fail the image build rather than shipping a Boost the project cannot find.
 RUN test -f /usr/local/include/boost/version.hpp && \
-    grep -q 'BOOST_LIB_VERSION "1_90"' /usr/local/include/boost/version.hpp && \
+    grep -q 'BOOST_LIB_VERSION "1_91"' /usr/local/include/boost/version.hpp && \
     test -f /usr/local/lib/cmake/Boost-${BOOST_VERSION}/BoostConfig.cmake

--- a/share/vizd/docker/Dockerfile-boost
+++ b/share/vizd/docker/Dockerfile-boost
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1.4
+#
+# Builder base image: phusion/baseimage:noble-1.0.3 plus Boost 1.90 built from
+# source.  Noble ships Boost 1.83, and viz needs to build against 1.9x, so the
+# Boost compile lives here rather than in the per-PR build.  This image is
+# rebuilt only when this file changes.
+#
+# Two constraints are load-bearing:
+#   * cxxflags=-std=c++14 must match the project's standard.  Boost's compiled
+#     libraries (Serialization, Test, Locale) can be ABI-incompatible when built
+#     at a different standard than the consumer, and that surfaces as a link
+#     error or a runtime surprise, not a compile error.
+#   * link=static keeps the viz runtime stage free of Boost .so files, matching
+#     the project's Boost_USE_STATIC_LIBS=TRUE default.
+#
+# Do NOT add a newer CMake here.  thirdparty/{fc,chainbase,appbase} declare
+# cmake_minimum_required(VERSION 2.8.12); CMake 4.x hard-errors below 3.5, while
+# noble's 3.28 only warns.
+FROM phusion/baseimage:noble-1.0.3
+
+ARG BOOST_VERSION=1.90.0
+ARG BOOST_VERSION_UNDERSCORE=1_90_0
+
+ENV LANG=en_US.UTF-8
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
+    for i in 1 2 3; do \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            autoconf \
+            automake \
+            autotools-dev \
+            binutils \
+            bsdmainutils \
+            build-essential \
+            cmake \
+            git \
+            ccache \
+            curl \
+            ca-certificates \
+            libbz2-dev \
+            liblzma-dev \
+            libzstd-dev \
+            libreadline-dev \
+            libssl-dev \
+            libtool \
+            libicu-dev \
+            ncurses-dev \
+            pbzip2 \
+            pkg-config \
+            zlib1g-dev && \
+        break || sleep 10; \
+    done
+
+RUN set -xe ; \
+    curl -fsSL -o /tmp/boost.tar.gz \
+        "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" && \
+    tar -xzf /tmp/boost.tar.gz -C /tmp && \
+    cd "/tmp/boost_${BOOST_VERSION_UNDERSCORE}" && \
+    ./bootstrap.sh --prefix=/usr/local \
+        --with-libraries=chrono,context,coroutine,date_time,filesystem,iostreams,locale,program_options,serialization,system,test,thread && \
+    ./b2 -j"$(nproc)" \
+        variant=release \
+        link=static \
+        threading=multi \
+        runtime-link=shared \
+        cxxflags="-std=c++14 -fPIC" \
+        install && \
+    rm -rf /tmp/boost.tar.gz "/tmp/boost_${BOOST_VERSION_UNDERSCORE}"
+
+# Fail the image build rather than shipping a Boost the project cannot find.
+RUN test -f /usr/local/include/boost/version.hpp && \
+    grep -q 'BOOST_LIB_VERSION "1_90"' /usr/local/include/boost/version.hpp && \
+    test -f /usr/local/lib/cmake/Boost-${BOOST_VERSION}/BoostConfig.cmake


### PR DESCRIPTION
## Publish the Boost 1.91 builder base image

Adds the prebuilt Boost 1.91 builder image plumbing, split out so it can land independently of the migration (#131).

- `share/vizd/docker/Dockerfile-boost` — builds Boost 1.91 on Noble (static libs + `BoostConfig.cmake`), ~7.5 min. The compiled `system` library is not built: 1.91 dropped the stub (Boost.System is header-only since 1.69) and `b2` errors on it as an unknown `--with-libraries` name.
- `.github/workflows/boost-base-image.yml` — builds and pushes the base image. Triggers on `workflow_dispatch` or a push to `master` touching either file.

### Where the image is published
The base image is stored as a **tag on the existing `vizblockchain/vizd` repo**: `vizblockchain/vizd:boost-base-1.91-noble`. The CI Docker Hub account can push tags to repos that already exist but **cannot create a new repo** (`vizblockchain/boost` → `push access denied, insufficient_scope`), so a dedicated repo isn't an option without an org-side grant. The tag is already **published and live**. If a dedicated `vizblockchain/boost` repo is provisioned later, flip the tag reference here and in #131.

### Status
The temporary publish trigger (which listed `ci/boost-base-image` under `push:` so the image could be built before merge) has been **removed** — the workflow now publishes only on pushes to `master`. This branch is clean to merge.
