### PR TITLE
ci(windows): fix Boost CONFIG-mode discovery; guard release to master

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -160,7 +160,7 @@ jobs:
             -DBOOST_ROOT="/c/Boost" \
             -DBOOST_INCLUDEDIR="/c/Boost/include/boost-1_86" \
             -DBOOST_LIBRARYDIR="/c/Boost/lib" \
-            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_PREFIX_PATH="/c/Boost" \
             -DBoost_NO_SYSTEM_PATHS=ON \
             -DBoost_USE_STATIC_LIBS=ON \
             -DBoost_USE_STATIC_RUNTIME=ON \
@@ -214,7 +214,10 @@ jobs:
       # -------------------------------------------------------
       # 13. Create GitHub Release and upload artifacts
       # -------------------------------------------------------
+      # Only master publishes a release. Pushes to windows_build exercise the
+      # full build (a test lane for CI changes) without creating win-<sha> tags.
       - name: Create GitHub Release and upload artifacts
+        if: github.ref == 'refs/heads/master'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Fix the Windows Release broken by the Boost CONFIG-mode migration

The Boost 1.9x migration (#131) moved `CMakeLists.txt` to
`find_package(Boost 1.83 CONFIG REQUIRED ...)`, which is correct on Linux and
required by modern CMake (the bundled `FindBoost` module was removed in 3.30).
But `windows-release.yml` fought CONFIG mode: it passed
`-DBoost_NO_BOOST_CMAKE=ON` and pointed only the **all-caps** `BOOST_ROOT` at
`C:/Boost`. In pure CONFIG mode `BOOST_ROOT` is not a search hint, so CMake
never looked in `C:/Boost/lib/cmake/…`, couldn't find `BoostConfig.cmake`, and
configure failed on the first post-merge master run
([run 30976582512](https://github.com/VIZ-Blockchain/viz-cpp-node/actions/runs/30976582512)).

### Fix
- Point `CMAKE_PREFIX_PATH` at `C:/Boost` (the job's `b2 install` already writes
  the CMake config there) and drop `-DBoost_NO_BOOST_CMAKE=ON`.
- Gate the release step on `master` so pushes to `windows_build` exercise the
  full build as a CI test lane **without** publishing `win-<sha>` releases.

### Validation
Pushed to `windows_build` — the whole job is green (Configure → Build vizd →
Build cli_wallet → Verify), and the release step correctly **skipped** on the
non-master branch. Boost stays at 1.86 (in the supported 1.83–1.9x range).
