### PR TITLE
fix(p2p): stop nodes from dialing and banning themselves

### DIFF
--- a/libraries/network/dlt_p2p_node.cpp
+++ b/libraries/network/dlt_p2p_node.cpp
@@ -310,10 +310,12 @@ static dlt_hello_message unpack_hello_compat(const message& msg) {
 // This correctly handles multiple nodes behind the same NAT (same IP, different
 // ports) — each node has a unique keypair, so only true duplicates are rejected.
 // Returns INVALID_PEER_ID for zero node_id (old peer that didn't send one).
-dlt_p2p_node::peer_id dlt_p2p_node::find_active_peer_by_node_id(const node_id_t& nid) const {
+dlt_p2p_node::peer_id dlt_p2p_node::find_active_peer_by_node_id(const node_id_t& nid,
+                                                                peer_id exclude) const {
     static const node_id_t zero_id;
     if (nid == zero_id) return INVALID_PEER_ID;
     for (const auto& item : _peer_states) {
+        if (item.first == exclude) continue;
         const auto& state = item.second;
         if (state.node_id == nid &&
             (state.lifecycle_state == DLT_PEER_LIFECYCLE_CONNECTING ||
@@ -1129,6 +1131,27 @@ void dlt_p2p_node::on_dlt_hello(peer_id peer, const dlt_hello_message& hello) {
     // Persist node_id — used for dedup and peer-exchange identity.
     state.node_id = hello.node_id;
 
+    // ── Self-connection guard ───────────────────────────────────────────────
+    // The hello carries OUR node_id ⇒ this socket ends at our own listener.
+    // Happens whenever a loopback/LAN endpoint reaches us (peer exchange
+    // gossips whatever its sender has connected, and a seed entry can point at
+    // us).  Both directions of the self-dial then live on as ACTIVE peers:
+    // they inflate the peer count, dilute the wedge watchdog's corroboration
+    // set, re-advertise the bogus endpoint to everyone else — and a soft-ban
+    // aimed at "that peer" is delivered right back to us, so the node bans
+    // itself.  Drop the connection and forget the endpoint so
+    // periodic_reconnect_check() does not immediately dial it again.
+    static const node_id_t zero_node_id;
+    if (hello.node_id != zero_node_id && hello.node_id == _node_id) {
+        wlog(DLT_LOG_RED "Connected to ourselves at ${ep} — dropping and forgetting the endpoint" DLT_LOG_RESET,
+             ("ep", state.endpoint));
+        dlt_known_peer self_kp;
+        self_kp.endpoint = state.endpoint;
+        _known_peers.erase(self_kp);
+        handle_disconnect(peer, "self-connection");
+        return;
+    }
+
     // ── Post-hello node_id dedup ────────────────────────────────────────────
     // Now that we know the remote node's identity, check if we already have an
     // active connection to the exact same node.  This correctly handles:
@@ -1138,8 +1161,11 @@ void dlt_p2p_node::on_dlt_hello(peer_id peer, const dlt_hello_message& hello) {
     // each node generates a unique keypair (node_id).
     static const node_id_t zero_id;
     if (hello.node_id != zero_id) {
-        peer_id dup = find_active_peer_by_node_id(hello.node_id);
-        if (dup != INVALID_PEER_ID && dup != peer) {
+        // Exclude ourselves from the scan: state.node_id was just set above, so
+        // an unexcluded scan can return `peer` itself (map order is by peer_id)
+        // and the `dup != peer` test would silently skip the disconnect.
+        peer_id dup = find_active_peer_by_node_id(hello.node_id, /*exclude=*/peer);
+        if (dup != INVALID_PEER_ID) {
             auto dup_it = _peer_states.find(dup);
             auto dup_ep = (dup_it != _peer_states.end()) ? dup_it->second.endpoint : fc::ip::endpoint();
             dlog(DLT_LOG_DGRAY "Closing duplicate connection from ${ep} "
@@ -1976,6 +2002,7 @@ void dlt_p2p_node::on_dlt_peer_exchange_request(peer_id peer, const dlt_peer_exc
         if (!s.exchange_enabled) continue;
         if (s.lifecycle_state != DLT_PEER_LIFECYCLE_ACTIVE) continue;
         if (s.is_incoming) continue;  // ephemeral source ports are not reconnectable
+        if (!is_routable_endpoint(s.endpoint)) continue;  // loopback/LAN: meaningless off this host
         if (s.connected_since == fc::time_point()) continue;
         auto uptime = (now - s.connected_since).count() / 1000000;
         if (uptime < _peer_exchange_min_uptime_sec) continue;
@@ -2018,6 +2045,13 @@ void dlt_p2p_node::on_dlt_peer_exchange_reply(peer_id peer, const dlt_peer_excha
     for (auto& info : reply.peers) {
         // Filter out self by node_id (NAT-aware: same public IP, different node)
         if (info.node_id == _node_id) continue;
+
+        // Never adopt an endpoint that only means something on the sender's
+        // host — 127.0.0.1:2001 from a peer running a local pair would make us
+        // dial our OWN listener.  Peers still running the unfiltered code keep
+        // gossiping these, so the adopt side must reject them too.  Explicitly
+        // configured seeds are unaffected: they never pass through here.
+        if (!is_routable_endpoint(info.endpoint)) continue;
 
         // _known_peers is keyed on endpoint only.  If we already have this
         // endpoint, just refresh metadata (last_seen + best-effort node_id)

--- a/libraries/network/include/graphene/network/dlt_p2p_node.hpp
+++ b/libraries/network/include/graphene/network/dlt_p2p_node.hpp
@@ -328,13 +328,33 @@ public:
             && elapsed_sec >= WEDGE_CONFIRM_SEC;
     }
 
+    // Is this endpoint meaningful to anyone but the host that advertises it?
+    // Loopback, RFC1918, link-local, multicast, 0.0.0.0 and port 0 are not:
+    // gossiping one through peer exchange makes every receiver dial its OWN
+    // box.  A node that adopts 127.0.0.1:2001 connects to itself, keeps both
+    // directions of that connection as peers, and then re-advertises the same
+    // endpoint — so a single poisoned entry spreads across the network and is
+    // self-sustaining.  fc's is_public_address() covers RFC1918/link-local/
+    // multicast but NOT 127/8 or 0/8, so those are checked explicitly.
+    // Pure and I/O-free — table-testable, hence public alongside is_wedged().
+    static bool is_routable_endpoint(const fc::ip::endpoint& ep) {
+        if (ep.port() == 0) return false;
+        const uint32_t first_octet = static_cast<uint32_t>(ep.get_address()) >> 24;
+        if (first_octet == 127 || first_octet == 0) return false;
+        return ep.get_address().is_public_address();
+    }
+
 private:
     // ── Subnet diversity ─────────────────────────────────────────
     uint32_t count_peers_in_subnet(const fc::ip::address& addr) const;
     bool is_same_subnet(const fc::ip::address& a, const fc::ip::address& b) const;
 
     // ── Per-IP dedup ─────────────────────────────────────────────
-    peer_id find_active_peer_by_node_id(const node_id_t& nid) const;
+    /// @param exclude peer to skip — the caller's own peer_id, which already
+    ///        carries @p nid by the time it asks (otherwise the scan returns
+    ///        the caller itself and the duplicate check silently no-ops).
+    peer_id find_active_peer_by_node_id(const node_id_t& nid,
+                                        peer_id exclude = INVALID_PEER_ID) const;
 
 private:
     dlt_p2p_delegate*               _delegate = nullptr;

--- a/tests/consensus_sim/CMakeLists.txt
+++ b/tests/consensus_sim/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SCENARIO_SOURCES
     scenarios/test_determinism_replay.cpp
     scenarios/test_equivocation.cpp
     scenarios/test_wedge_predicate.cpp
+    scenarios/test_routable_endpoint.cpp
 )
 
 add_executable(consensus_sim_tests ${SCENARIO_SOURCES})
@@ -64,6 +65,7 @@ add_executable(consensus_sim_tests ${SCENARIO_SOURCES})
 target_link_libraries(consensus_sim_tests
     PRIVATE consensus_sim_harness
             graphene::network         # test_wedge_predicate.cpp: dlt_p2p_node::is_wedged
+                                      # test_routable_endpoint.cpp: is_routable_endpoint
             Boost::unit_test_framework
 )
 

--- a/tests/consensus_sim/scenarios/test_routable_endpoint.cpp
+++ b/tests/consensus_sim/scenarios/test_routable_endpoint.cpp
@@ -1,0 +1,57 @@
+// Guard for dlt_p2p_node::is_routable_endpoint().
+//
+// Peer exchange gossips whatever endpoints its sender has connected.  Without
+// this filter a node running a local pair advertises 127.0.0.1:2001 to the
+// whole network; every receiver adopts it, dials its OWN listener, keeps both
+// directions of the self-dial as ACTIVE peers, and re-advertises the same
+// endpoint — a self-sustaining loop that inflates peer counts, dilutes the
+// wedge watchdog's corroboration set and lets a soft-ban land back on the node
+// that issued it.  The predicate is the sole gate on both the share side and
+// the adopt side, so pin its boundaries.
+
+#include <boost/test/unit_test.hpp>
+
+#include <graphene/network/dlt_p2p_node.hpp>
+
+using graphene::network::dlt_p2p_node;
+
+namespace {
+bool routable(const char* ep) {
+    return dlt_p2p_node::is_routable_endpoint(fc::ip::endpoint::from_string(ep));
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(routable_endpoint)
+
+BOOST_AUTO_TEST_CASE(public_endpoints_are_routable) {
+    BOOST_CHECK(routable("175.110.112.214:2001"));
+    BOOST_CHECK(routable("8.8.8.8:2001"));
+    BOOST_CHECK(routable("172.32.0.1:2001"));   // just outside 172.16/12
+    BOOST_CHECK(routable("126.255.255.255:2001"));
+    BOOST_CHECK(routable("128.0.0.1:2001"));    // just outside 127/8
+}
+
+BOOST_AUTO_TEST_CASE(loopback_is_never_routable) {
+    // The endpoint pair from the field report: the outbound self-dial and the
+    // accepted side of the same connection.
+    BOOST_CHECK(!routable("127.0.0.1:2001"));
+    BOOST_CHECK(!routable("127.0.0.1:36702"));
+    BOOST_CHECK(!routable("127.255.255.255:2001"));
+}
+
+BOOST_AUTO_TEST_CASE(private_and_unspecified_are_never_routable) {
+    BOOST_CHECK(!routable("10.0.0.1:2001"));
+    BOOST_CHECK(!routable("172.16.0.1:2001"));
+    BOOST_CHECK(!routable("172.31.255.255:2001"));
+    BOOST_CHECK(!routable("192.168.1.10:2001"));
+    BOOST_CHECK(!routable("169.254.1.1:2001"));   // link-local
+    BOOST_CHECK(!routable("224.0.0.1:2001"));     // multicast
+    BOOST_CHECK(!routable("0.0.0.0:2001"));       // unspecified
+}
+
+BOOST_AUTO_TEST_CASE(port_zero_is_never_routable) {
+    // A hostname seed that resolved without a port yields port 0 — not dialable.
+    BOOST_CHECK(!routable("175.110.112.214:0"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Field report

A mainnet node showed `127.0.0.1:2001` and `127.0.0.1:36702` as ACTIVE peers — the two ends of one self-dial — and soft-banned itself. `p2p-isolated-peers` was the operator's workaround. The node had just been updated for the Boost 1.91 release, but that is coincidental: the fc diff in that release is API renames only (`to_ulong`→`to_uint`, `from_string`→`make_address_v4`, `resolver::query`→`async_resolve`, `io_service`→`io_context`) — no change to address values or peer selection. The restart is simply what re-ran discovery.

## Root cause

Three defects line up:

1. **Peer exchange gossips non-routable endpoints.** `on_dlt_peer_exchange_request` advertises the raw endpoint of every outbound ACTIVE peer, and `on_dlt_peer_exchange_reply` adopts and dials anything it is handed. A node running a local validator+relay pair (`p2p-seed-node = 127.0.0.1:2001`) therefore advertises loopback to the whole network; every receiver dials its **own** listener. Once connected, that loopback peer is outbound+ACTIVE, so the receiver re-advertises it — the loop is self-sustaining and spreads. The `info.node_id == _node_id` filter does not help: the node_id on that entry belongs to the sender's local relay.

2. **No self-connection guard.** `on_dlt_hello` never compared `hello.node_id` to `_node_id`. Both directions of the self-dial stay ACTIVE: they inflate the peer count, feed `check_wedge_watchdog`'s corroboration set with our own head, and a `soft_ban_peer()` notification aimed at "that peer" is delivered straight back to us — the node bans itself (`"Peer 127.0.0.1:2001 soft-banned us"`).

3. **The duplicate-node_id guard was inert.** `find_active_peer_by_node_id()` scans `_peer_states` in peer_id order, and `state.node_id` is assigned just before the call, so the scan can return the calling peer itself and the `dup != peer` test silently no-ops. This also let duplicate inbound+outbound connections to real peers survive.

## Changes

- `is_routable_endpoint()` — pure predicate rejecting loopback, RFC1918, link-local, multicast, `0.0.0.0` and port 0. `fc`'s `is_public_address()` covers everything except 127/8 and 0/8, so those are explicit.
- Applied on **both** sides of peer exchange. The adopt side is load-bearing: peers still running the old code keep gossiping these endpoints. Explicitly configured seeds never pass through peer exchange, so deliberate LAN/loopback clusters still peer as configured.
- Self-connection guard in `on_dlt_hello`: drop the socket and erase the endpoint from `_known_peers` so `periodic_reconnect_check()` does not redial it.
- `find_active_peer_by_node_id(nid, exclude)` — makes the existing dedup actually fire.
- `test_routable_endpoint.cpp` pins the predicate boundaries, mirroring `test_wedge_predicate.cpp`.

## Verification

- `-fsyntax-only` replay of the tree's real compile command for `dlt_p2p_node.cpp` (worktree includes first): clean, only pre-existing warnings. Same for the new test TU at C++17.
- Host-order octet arithmetic checked against Boost.Asio directly.
- **Not built or run locally** — any fc consumer pulls `vendor/equihash` (SSE2-only), which does not link on arm64. CI's amd64 build is the first real compile+link, and `BUILD_CONSENSUS_TESTS` is still OFF there, so the new test does not execute in CI yet (same status as `test_wedge_predicate.cpp`).
- No live two-node repro yet. The field check is: deploy, remove `p2p-isolated-peers`, confirm no `127.0.0.1` entries appear in `DLT P2P Stats`.