### PR TITLE
fix(snapshot): import pm_oracle oracle-metrics fields (P1-P5)

### DIFF
--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -820,6 +820,19 @@ inline uint32_t import_pm_oracles(graphene::chain::database& db, const fc::varia
                 obj.auto_accept_resolver = v["auto_accept_resolver"].as<account_name_type>();
             if (v.get_object().contains("auto_accept"))
                 obj.auto_accept          = v["auto_accept"].as<bool>();
+            // Oracle-metrics fields (P1-P5, display-only): forward-compatible import so a snapshot
+            // taken after the upgrade keeps the gauges/histogram; old snapshots (fields absent)
+            // stay zeroed and pm_seed_oracle_gauges() re-derives the gauges on the next block.
+            if (v.get_object().contains("markets_in_dispute_window"))
+                obj.markets_in_dispute_window  = static_cast<uint32_t>(v["markets_in_dispute_window"].as_uint64());
+            if (v.get_object().contains("disputes_awaiting_response"))
+                obj.disputes_awaiting_response = static_cast<uint32_t>(v["disputes_awaiting_response"].as_uint64());
+            if (v.get_object().contains("disputes_awaiting_decision"))
+                obj.disputes_awaiting_decision = static_cast<uint32_t>(v["disputes_awaiting_decision"].as_uint64());
+            if (v.get_object().contains("resolved_late_count"))
+                obj.resolved_late_count  = static_cast<uint32_t>(v["resolved_late_count"].as_uint64());
+            if (v.get_object().contains("resolution_time_hist"))
+                obj.resolution_time_hist = v["resolution_time_hist"].as<fc::array<share_type, 8>>();
         });
         ++count;
     }


### PR DESCRIPTION
## Summary

Follow-up to the P1-P5 oracle-metrics commits on `pm` (#124): `import_pm_oracles()` in `plugins/snapshot/plugin.cpp` skipped the five new display-only `pm_oracle_object` fields, so a snapshot taken after the upgrade lost them on import.

## Why it matters

- **Gauges** (`markets_in_dispute_window`, `disputes_awaiting_response`, `disputes_awaiting_decision`): were only recoverable when `dgpo.pm_oracle_gauges_seeded` was absent; if a post-upgrade snapshot carried the seeded flag, they stayed zeroed.
- **`resolved_late_count` + `resolution_time_hist`**: forward-accumulating (no seed) — previously impossible to recover on snapshot import; the histogram and late counter silently reset to 0.

## Change

`plugins/snapshot/plugin.cpp`, inside `import_pm_oracles()`:

```cpp
if (v.get_object().contains("markets_in_dispute_window"))
    obj.markets_in_dispute_window  = static_cast<uint32_t>(v["markets_in_dispute_window"].as_uint64());
if (v.get_object().contains("disputes_awaiting_response"))
    obj.disputes_awaiting_response = static_cast<uint32_t>(v["disputes_awaiting_response"].as_uint64());
if (v.get_object().contains("disputes_awaiting_decision"))
    obj.disputes_awaiting_decision = static_cast<uint32_t>(v["disputes_awaiting_decision"].as_uint64());
if (v.get_object().contains("resolved_late_count"))
    obj.resolved_late_count  = static_cast<uint32_t>(v["resolved_late_count"].as_uint64());
if (v.get_object().contains("resolution_time_hist"))
    obj.resolution_time_hist = v["resolution_time_hist"].as<fc::array<share_type, 8>>();
```

Forward-compatible: `contains()` guards mean pre-upgrade snapshots (fields absent) import cleanly and keep the existing seed-on-first-block behavior; post-upgrade snapshots preserve gauges and the histogram.

`fc::array<share_type, 8>` serializes through FC_REFLECT as a base64 `vector<char>` and reads back via the generic `from_variant` (already used in this plugin for `packed_trx` etc.).

## Verification

- `git diff --check` clean; single file, 13 insertions, no other changes.
- Display-only fields; no consensus impact (P1-P5 commits explicitly marked them non-gating).
- Full C++ build not run here (no local Boost toolchain); the change mirrors the surrounding `contains()`-guarded import style exactly.