### PR TITLE
fix(pm): compute avg_resolution_time running mean in uint128

### DIFF
--- a/libraries/chain/pm_evaluator.cpp
+++ b/libraries/chain/pm_evaluator.cpp
@@ -1643,10 +1643,14 @@ void pm_resolve_market_evaluator::do_apply(const pm_resolve_market_operation& o)
             ora.total_volume_resolved += mkt.bets_sum;
             if (late) ora.resolved_late_count++;
             // Running mean resolution latency over all resolves (n just incremented above).
+            // uint128 intermediate: avg_resolution_time (uint32) * (n-1) can overflow uint64
+            // once n grows large (e.g. ~4.3e9 markets), so accumulate in 128 bits.
             {
                 const uint64_t n = ora.markets_resolved;
-                ora.avg_resolution_time =
-                    (uint32_t)(((uint64_t)ora.avg_resolution_time * (n - 1) + rt) / n);
+                const uint64_t sum =
+                    ((fc::uint128_t((uint64_t)ora.avg_resolution_time) * (uint64_t)(n - 1)
+                      + fc::uint128_t(rt)) / n).lo;
+                ora.avg_resolution_time = (uint32_t)sum;
             }
             ora.resolution_time_hist[pm_rt_bucket(rt)] += share_type(1);   // P5 latency distribution
             ora.last_active_time = now;


### PR DESCRIPTION
## Summary

Small follow-up to P5 (oracle-metrics) on `pm` (#124): the running-mean formula for `pm_oracle_object::avg_resolution_time` accumulates in `uint64`, but `avg_resolution_time (uint32) * (n-1) + rt` can reach the `uint64` boundary once `n` approaches the `uint32` max — the product of two `uint32` values sits within a hair of `2^64`, and adding `rt` can tip it over.

## Change

`libraries/chain/pm_evaluator.cpp`, in `pm_resolve_market_evaluator::do_apply`:

```cpp
const uint64_t sum =
    ((fc::uint128_t((uint64_t)ora.avg_resolution_time) * (uint64_t)(n - 1)
      + fc::uint128_t(rt)) / n).lo;
ora.avg_resolution_time = (uint32_t)sum;
```

`fc::uint128_t` is already used elsewhere in the same file (time-penalty math), so no new includes.

## Verification

- Formula equivalence checked against the original integer math on boundary cases (`avg=0..UINT32_MAX`, `n=1..4e9`, `rt=0..UINT32_MAX`) — matches on all cases, and confirms the original `uint64` path lands within 1 bit of overflow on the extreme (`bit_length()==64`).
- `git diff --check` clean; single file, 6 insertions / 2 deletions.
- Full C++ build not run here (no local Boost toolchain); change is a pure arithmetic widening with identical semantics.