### PR TITLE
fix(pm): stop batch-epoch settle from starving markets behind the processing cap

### DIFF
--- a/libraries/chain/pm_evaluator.cpp
+++ b/libraries/chain/pm_evaluator.cpp
@@ -3115,12 +3115,14 @@ void database::process_pm_markets() {
             auto bit = bidx.lower_bound(boost::make_tuple(
                 mkt.id, (uint32_t)mkt.current_epoch, pm_bet_id_type()));
             uint32_t settled = 0;
+            bool     had_queued = false;
 
             while (bit != bidx.end() &&
                    bit->market == mkt.id &&
                    bit->epoch  == (uint32_t)mkt.current_epoch) {
                 const auto& bet = *bit; ++bit;
                 if (bet.status != 5) continue;
+                had_queued = true;
 
                 share_type tokens(0);
 
@@ -3196,8 +3198,17 @@ void database::process_pm_markets() {
                 push_virtual_operation(pm_batch_settle_operation(
                     mkt.id._id, mkt.current_epoch, settled));
 
-            modify(mkt, [](pm_market_object& m) { m.current_epoch++; });
-            ++done;
+            // Only advance the epoch and consume the per-block processing cap for markets
+            // that actually had queued (status=5) bets this epoch. Previously EVERY
+            // allow_batch market did `current_epoch++` and `++done`, so once the number of
+            // active allow_batch markets exceeded pm_processing_cap_per_block the loop
+            // stopped on the ~cap oldest markets and newer markets never got their queued
+            // bets settled (starvation). Skipping idle markets keeps the cap budget for
+            // markets that need work and lets the scan reach newly-created markets.
+            if (had_queued) {
+                modify(mkt, [](pm_market_object& m) { m.current_epoch++; });
+                ++done;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Found during testnet QA (2026-08-07): a revealed commit-reveal bet on market 274356 stayed `status=5` (queued) forever across many epoch boundaries, while `current_epoch` remained 0. Old markets (id 19–28) had `current_epoch=45899` and settled fine.

## Root cause

`database::process_pm_markets()` section 6 (batch epoch settle):

```cpp
while (mit != midx.end() && mit->status == 1 && done < cap) {
    const auto& mkt = *mit; ++mit;
    if (!mkt.allow_batch) continue;
    ...
    modify(mkt, [](pm_market_object& m) { m.current_epoch++; });
    ++done;
}
```

Every active `allow_batch` market consumed the shared `pm_processing_cap_per_block` budget (`++done`) and bumped `current_epoch`, even when it had zero queued bets. With more active allow_batch markets than the cap (testnet has 50k+ polymarket mirror markets vs `cap=200`), the loop stopped after the ~cap **oldest** markets (by_status orders by status then id) and never reached newly-created markets — their queued bets never settled.

## Change

`libraries/chain/pm_evaluator.cpp`:

- Track `had_queued` — set when any `status==5` bet is found for the market this epoch.
- Only `current_epoch++` and `++done` when `had_queued` is true. Idle markets are skipped without touching the cap, so the scan can reach newly-created markets and settle their bets on the next epoch boundary.

Slippage-refund paths still count as work (`had_queued` covers both settled and refunded bets), so a market that only produces refunds still advances its epoch.

## Verification

- Reproduction on live testnet: market 274356 `current_epoch=0`, queued bet `35220` stuck at `status=5` before the fix; old markets at epoch 45899.
- Logic walk: with idle markets no longer consuming `done`, the loop continues past them to markets with queued bets.
- `git diff --check` clean; single file, 13 insertions / 2 deletions.
- Full C++ build not run here (no local Boost toolchain); the change is a control-flow guard around existing code paths.