### PR TITLE
test(pm): consensus_sim zero-sum supply + early-exit deferred-claim coverage (PR #124)

### DIFF
--- a/tests/consensus_sim/scenarios/test_pm_lifecycle.cpp
+++ b/tests/consensus_sim/scenarios/test_pm_lifecycle.cpp
@@ -5396,4 +5396,277 @@ BOOST_AUTO_TEST_CASE(batch_settle_round_robin_prevents_busy_starvation) {
     BOOST_CHECK_GT(bet.weight.value, 0);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// End-to-end ZERO-SUM conservation through the REAL evaluators.
+//
+// The existing cases assert LOCAL money movement (this winner got X, this loser
+// got 0), and betting_odds_and_payout_table's check_zero_sum validates the pure
+// compute_settlement result struct — but nothing asserts that the CHAIN itself
+// neither mints nor burns across a full PM lifecycle driven through the live
+// database + evaluators + settlement cron. This is the PR's core safety claim
+// ("prediction markets never mint or burn; current_supply untouched").
+//
+// Method: VIZ supply may change ONLY by block inflation
+// (CHAIN_DIGITAL_ASSET_ISSUED_PER_BLOCK, credited to committee/reward-fund/validator —
+// never minted or burned by PM). So across a full PM lifecycle current_supply must
+// grow by exactly inflation × (blocks produced); any PM mint/burn is a deviation.
+
+// A binary market with fees, an LP, and unequal bets on both sides. Assert the chain's
+// current_supply grows by exactly block inflation across the full lifecycle (no PM mint/burn).
+BOOST_AUTO_TEST_CASE(supply_conserved_binary_lifecycle) {
+    auto gp = make_genesis_params(0x5C01u, 1);
+    fc::time_point_sec start(fc::time_point::now());
+    fc::time_point_sec hf(CHAIN_HARDFORK_14_TIME);
+    if (hf > start) start = hf;
+    start += fc::seconds(CHAIN_BLOCK_INTERVAL);
+    virtual_clock clk(start);
+    simulated_node node("pm-supply", gp, clk);
+    fc::time_point_sec when = start - fc::seconds(CHAIN_BLOCK_INTERVAL);
+
+    if (!bring_to_hf14(node, gp, when)) {
+        BOOST_TEST_MESSAGE("HF14 not reachable; skipping supply-conservation lifecycle.");
+        return;
+    }
+
+    const auto& mp = node.db().get_validator_schedule_object().median_props;
+    const int64_t unit = mp.pm_min_liquidity.amount.value;
+
+    // Short dispute grace so the auto-payout cron settles within a few blocks.
+    {
+        chain_properties_pm props;
+        props.pm_dispute_grace_sec = 30;
+        versioned_chain_properties_update_operation vp;
+        vp.owner = gp.initiator_name; vp.props = props;
+        node.push_pending_transaction(sign_ops({vp}, gp.initiator_key, node));
+        for (int i = 0; i < 60 && mp.pm_dispute_grace_sec != 30; ++i) produce(node, gp, when);
+        BOOST_REQUIRE_EQUAL(mp.pm_dispute_grace_sec, 30u);
+    }
+
+    // Oracle "viz" with a nonzero % fee schedule so oracle/creator/LP takes are all exercised.
+    pm_oracle_register_operation oreg;
+    oreg.owner = gp.initiator_name; oreg.insurance = mp.pm_min_oracle_insurance;
+    oreg.fixed_fee = asset(0, TOKEN_SYMBOL); oreg.rules_url = "";
+    node.push_pending_transaction(sign_ops({oreg}, gp.initiator_key, node));
+    produce(node, gp, when);
+
+    auto alice_key = derive_key("alice"), bob_key = derive_key("bob"), lp_key = derive_key("liz");
+    create_and_fund(node, gp, when, "alice", alice_key, share_type(unit * 8));
+    create_and_fund(node, gp, when, "bob",   bob_key,   share_type(unit * 8));
+    create_and_fund(node, gp, when, "liz",    lp_key,    share_type(unit * 8));
+
+    pm_create_market_operation cm;
+    cm.creator = gp.initiator_name; cm.oracle = gp.initiator_name;
+    cm.market_type = 0; cm.outcomes = {"A", "B"}; cm.url = "criteria";
+    cm.liquidity = asset(share_type(unit * 4), TOKEN_SYMBOL);
+    cm.oracle_fee_percent = 200; cm.creator_fee_percent = 100; cm.liquidity_fee_percent = 300; // 6% total
+    cm.betting_expiration = node.head_block_time() + fc::seconds(30);
+    cm.result_expiration  = node.head_block_time() + fc::seconds(90);
+    cm.allow_early_resolution = true;
+    cm.dispute_mode = 0;
+    node.push_pending_transaction(sign_ops({cm}, gp.initiator_key, node));
+    produce(node, gp, when);
+    const pm_market_id_type market_id(0);
+    BOOST_REQUIRE_EQUAL(node.db().get<pm_market_object>(market_id).status, 1);
+
+    // An extra LP adds depth (its principal returns at settlement + a fee share).
+    pm_add_liquidity_operation al;
+    al.provider = "liz"; al.market_id = 0; al.amount = asset(share_type(unit * 4), TOKEN_SYMBOL);
+    node.push_pending_transaction(sign_ops({al}, lp_key, node));
+    produce(node, gp, when);
+
+    // Global zero-sum test: VIZ supply may change ONLY by block inflation
+    // (CHAIN_DIGITAL_ASSET_ISSUED_PER_BLOCK = 1000 mVIZ/block, credited to committee/
+    // reward-fund/validator — never minted or burned by PM). So across the whole PM
+    // lifecycle current_supply must grow by exactly 1000 × (blocks produced). Any PM
+    // mint/burn shows up as a deviation. This is the invariant the suite never asserted.
+    const int64_t supply_before = node.db().get_dynamic_global_properties().current_supply.amount.value;
+    const uint32_t num_before = node.db().head_block_num();
+
+    // Unequal bets on both sides so losers_sum > 0 and the parimutuel split is nontrivial.
+    pm_place_bet_operation ba; ba.account = "alice"; ba.market_id = 0; ba.side = 0; ba.outcome_index = -1;
+    ba.amount = asset(share_type(unit * 3), TOKEN_SYMBOL); ba.mode = 0;
+    pm_place_bet_operation bb; bb.account = "bob"; bb.market_id = 0; bb.side = 1; bb.outcome_index = -1;
+    bb.amount = asset(share_type(unit * 2), TOKEN_SYMBOL); bb.mode = 0;
+    node.push_pending_transaction(sign_ops({ba}, alice_key, node));
+    node.push_pending_transaction(sign_ops({bb}, bob_key, node));
+    produce(node, gp, when);
+
+    // Betting closes, oracle resolves A (side 0), auto-payout cron settles.
+    for (int i = 0; i < 15; ++i) produce(node, gp, when);
+    pm_resolve_market_operation rm;
+    rm.oracle = gp.initiator_name; rm.market_id = 0; rm.winning_outcome = 0; rm.decision_url = "";
+    node.push_pending_transaction(sign_ops({rm}, gp.initiator_key, node));
+    produce(node, gp, when);
+    const uint32_t grace = (uint32_t)mp.pm_dispute_grace_sec;
+    const int blocks = (int)((grace + 240) / CHAIN_BLOCK_INTERVAL) + 80;
+    for (int i = 0; i < blocks && node.db().get<pm_market_object>(market_id).payout_status != 3; ++i)
+        produce(node, gp, when);
+    BOOST_REQUIRE_EQUAL(node.db().get<pm_market_object>(market_id).payout_status, 3);
+
+    const int64_t supply_after = node.db().get_dynamic_global_properties().current_supply.amount.value;
+    const uint32_t num_after = node.db().head_block_num();
+
+    const int64_t inflation = (int64_t)(num_after - num_before) * CHAIN_DIGITAL_ASSET_ISSUED_PER_BLOCK;
+    const int64_t supply_delta = supply_after - supply_before;
+    BOOST_TEST_MESSAGE("supply: before=" << supply_before << " after=" << supply_after
+                       << " delta=" << supply_delta << " expected_inflation=" << inflation
+                       << " (blocks=" << (num_after - num_before) << ")");
+    // Exact zero-sum: the entire PM lifecycle (bets, LP, resolve, parimutuel settle, fees)
+    // moved value between accounts/pools but neither minted nor burned — supply grew by
+    // block inflation alone.
+    BOOST_CHECK_EQUAL(supply_delta, inflation);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F1/#300 early-exit deferred claim, driven through the REAL evaluators.
+//
+// The whole deferred-claim subsystem (leverage close/liquidate residual → contingent
+// claim → paid from a bounded slice of the losing pool at settlement) had ZERO
+// integration coverage: grep deferred/early_exit/claim_paid across tests/ = 0. This
+// exercises the money path end-to-end and asserts (a) a claim is recorded on a
+// profitable force-close, (b) the early-exiter is actually paid from the bucket when
+// their side wins, and (c) the market still conserves VIZ through settlement.
+BOOST_AUTO_TEST_CASE(early_exit_deferred_claim_paid_from_bucket) {
+    auto gp = make_genesis_params(0x5E02u, 1);
+    fc::time_point_sec start(fc::time_point::now());
+    fc::time_point_sec hf(CHAIN_HARDFORK_14_TIME);
+    if (hf > start) start = hf;
+    start += fc::seconds(CHAIN_BLOCK_INTERVAL);
+    virtual_clock clk(start);
+    simulated_node node("pm-earlyexit", gp, clk);
+    fc::time_point_sec when = start - fc::seconds(CHAIN_BLOCK_INTERVAL);
+
+    if (!bring_to_hf14(node, gp, when)) {
+        BOOST_TEST_MESSAGE("HF14 not reachable; skipping early-exit deferred claim.");
+        return;
+    }
+
+    const auto& mp = node.db().get_validator_schedule_object().median_props;
+    const int64_t unit = mp.pm_min_liquidity.amount.value;
+
+    // Enable leverage; short grace so the market settles quickly.
+    {
+        chain_properties_pm props;
+        props.pm_leverage_enabled                    = true;
+        props.pm_leverage_expiration_buffer_sec      = 0;
+        props.pm_leverage_fund_percent               = 100;
+        props.pm_leverage_max_per_position_bp        = 10000;
+        props.pm_leverage_max_position_ratio_percent = 100;
+        props.pm_lazy_alloc_percent                  = 0;
+        props.pm_dispute_grace_sec                   = 30;
+        versioned_chain_properties_update_operation vp;
+        vp.owner = gp.initiator_name; vp.props = props;
+        node.push_pending_transaction(sign_ops({vp}, gp.initiator_key, node));
+        for (int i = 0; i < 60 && !mp.pm_leverage_enabled; ++i) produce(node, gp, when);
+        BOOST_REQUIRE(mp.pm_leverage_enabled);
+    }
+
+    const pm_lazy_pool_id_type pool_id(0);
+    const int64_t D = unit * 100;
+    pm_lazy_deposit_operation dep;
+    dep.account = gp.initiator_name; dep.amount = asset(share_type(D), TOKEN_SYMBOL);
+    node.push_pending_transaction(sign_ops({dep}, gp.initiator_key, node));
+    produce(node, gp, when);
+
+    pm_create_market_operation cm;
+    cm.creator = gp.initiator_name; cm.oracle = gp.initiator_name;
+    cm.market_type = 0; cm.outcomes = {"A", "B"}; cm.url = "criteria";
+    cm.liquidity = asset(share_type(unit * 60), TOKEN_SYMBOL); // reserves 3M/3M
+    cm.betting_expiration = node.head_block_time() + fc::seconds(60);
+    cm.result_expiration  = node.head_block_time() + fc::seconds(120);
+    cm.allow_early_resolution = true;
+    cm.dispute_mode = 0;
+    node.push_pending_transaction(sign_ops({cm}, gp.initiator_key, node));
+    produce(node, gp, when);
+    const pm_market_id_type market_id(0);
+
+    auto trader_key = derive_key("trader"), whale_key = derive_key("whale"), bob_key = derive_key("bob");
+    create_and_fund(node, gp, when, "trader", trader_key, share_type(unit * 40));
+    create_and_fund(node, gp, when, "whale",  whale_key,  share_type(unit * 100));
+    create_and_fund(node, gp, when, "bob",    bob_key,    share_type(unit * 40));
+
+    // trader opens leverage on A; whale piles onto A (pushes trader's cancel_value above its
+    // loan → the position is in profit). bob bets B (the loser, funds the pool that pays claims).
+    const int64_t L = unit * 10;
+    pm_leverage_open_operation op;
+    op.account = "trader"; op.market_id = 0; op.outcome_index = 0;
+    op.collateral = asset(share_type(unit * 20), TOKEN_SYMBOL); op.loan = asset(share_type(L), TOKEN_SYMBOL);
+    op.min_tokens = 0; op.max_slippage_percent = 0;
+    node.push_pending_transaction(sign_ops({op}, trader_key, node));
+    produce(node, gp, when);
+    const pm_leverage_position_id_type pos_id(0);
+    BOOST_REQUIRE_EQUAL(node.db().get<pm_leverage_position_object>(pos_id).status, 0);
+
+    pm_place_bet_operation wb; wb.account = "whale"; wb.market_id = 0; wb.side = 0; wb.outcome_index = -1;
+    wb.amount = asset(share_type(unit * 80), TOKEN_SYMBOL); wb.mode = 0;
+    pm_place_bet_operation bb; bb.account = "bob"; bb.market_id = 0; bb.side = 1; bb.outcome_index = -1;
+    bb.amount = asset(share_type(unit * 20), TOKEN_SYMBOL); bb.mode = 0;
+    node.push_pending_transaction(sign_ops({wb}, whale_key, node));
+    node.push_pending_transaction(sign_ops({bb}, bob_key, node));
+    produce(node, gp, when);
+
+    const int64_t trader_before_close = node.db().get_account("trader").balance.amount.value;
+
+    // Close betting so the settlement force-close (reason 2) records the trader's profitable
+    // residual as an outcome-contingent deferred claim on side A (not an immediate refund).
+    for (int i = 0; i < 40 && node.head_block_time() < node.db().get<pm_market_object>(market_id).betting_expiration; ++i)
+        produce(node, gp, when);
+
+    // A deferred claim for the trader on outcome 0 should now exist (recorded at force-close).
+    auto count_claims = [&](account_name_type acct, int16_t outcome) {
+        uint32_t n = 0; int64_t total = 0;
+        const auto& cidx = node.db().get_index<pm_deferred_claim_index>().indices().get<by_claim_market>();
+        for (auto it = cidx.lower_bound(boost::make_tuple(market_id, pm_deferred_claim_id_type()));
+             it != cidx.end() && it->market == market_id; ++it)
+            if (it->account == acct && (int16_t)it->outcome_index == outcome) { ++n; total += it->claim_amount.value; }
+        return std::make_pair(n, total);
+    };
+    // The market's force-close cron runs at/after betting close; give it a couple of blocks.
+    for (int i = 0; i < 5 && count_claims("trader", 0).first == 0; ++i) produce(node, gp, when);
+    auto claim = count_claims("trader", 0);
+    {
+        const auto& pos = node.db().get<pm_leverage_position_object>(pos_id);
+        BOOST_TEST_MESSAGE("leverage pos after close: status=" << (int)pos.status
+                           << " cv_at_liq=" << pos.cancel_value_at_liquidation.value
+                           << " pool_received=" << pos.pool_received.value
+                           << " bettor_received=" << pos.bettor_received.value
+                           << " liq_threshold=" << pos.liquidation_threshold.value
+                           << " funding_paid=" << pos.funding_paid.value);
+    }
+    BOOST_TEST_MESSAGE("deferred claims for trader on A: n=" << claim.first << " total=" << claim.second);
+    BOOST_CHECK_GE(claim.first, 1u);          // a contingent claim was recorded
+    BOOST_CHECK_GT(claim.second, 0);          // for a positive (profit) amount
+
+    const int64_t trader_at_close = node.db().get_account("trader").balance.amount.value;
+    // The residual was DEFERRED, not refunded immediately: the trader's balance did not jump by
+    // the claim amount at close (it is paid only at settlement, iff A wins).
+    BOOST_CHECK_EQUAL(trader_at_close, trader_before_close);
+
+    // Resolve A (side 0) — the trader's outcome wins, so the deferred claim pays from the bucket.
+    pm_resolve_market_operation rm;
+    rm.oracle = gp.initiator_name; rm.market_id = 0; rm.winning_outcome = 0; rm.decision_url = "";
+    node.push_pending_transaction(sign_ops({rm}, gp.initiator_key, node));
+    produce(node, gp, when);
+    const uint32_t grace = (uint32_t)mp.pm_dispute_grace_sec;
+    const int blocks = (int)((grace + 240) / CHAIN_BLOCK_INTERVAL) + 80;
+    for (int i = 0; i < blocks && node.db().get<pm_market_object>(market_id).payout_status != 3; ++i)
+        produce(node, gp, when);
+    BOOST_REQUIRE_EQUAL(node.db().get<pm_market_object>(market_id).payout_status, 3);
+
+    // After settlement: the trader was paid their deferred claim (bounded by the early-exit
+    // bucket = cap% of losers_sum). Their balance rose from the close snapshot by > 0, and every
+    // deferred-claim row for the market is consumed (settlement removes them).
+    const int64_t trader_final = node.db().get_account("trader").balance.amount.value;
+    BOOST_TEST_MESSAGE("trader balance: before_close=" << trader_before_close
+                       << " at_close=" << trader_at_close << " final=" << trader_final
+                       << " (deferred paid=" << (trader_final - trader_at_close) << ")");
+    BOOST_CHECK_GT(trader_final, trader_at_close); // the contingent claim actually paid at settlement
+
+    uint32_t remaining = 0;
+    const auto& cidx = node.db().get_index<pm_deferred_claim_index>().indices().get<by_claim_market>();
+    for (auto it = cidx.lower_bound(boost::make_tuple(market_id, pm_deferred_claim_id_type()));
+         it != cidx.end() && it->market == market_id; ++it) ++remaining;
+    BOOST_CHECK_EQUAL(remaining, 0u); // all claims consumed at settlement (none leak to GC)
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Follow-up to #142 (the `t15` standalone replay, now merged). Adds two **CI-wired** `consensus_sim` cases to `tests/consensus_sim/scenarios/test_pm_lifecycle.cpp` that exercise the PM money paths through the **real evaluators + database + settlement cron** — closing the two coverage gaps flagged in the PR #124 round-4 review.

### `supply_conserved_binary_lifecycle`

A full binary-market lifecycle (create → extra LP add → unequal two-sided bets → oracle resolve → parimutuel settle with a 6% fee schedule) that asserts `current_supply` grows by **exactly** block inflation (`CHAIN_DIGITAL_ASSET_ISSUED_PER_BLOCK × blocks`).

This is the PR's core safety claim — *prediction markets never mint or burn; current_supply untouched* — asserted end-to-end for the first time. The existing 51-case suite checks local balances and the pure `compute_settlement` result struct, but `supply_conserved()` in the harness is a stub invoked 0× in the PM scenarios.

### `early_exit_deferred_claim_paid_from_bucket`

The `F1/#300` early-exit deferred-claim path had **zero** integration coverage (`grep deferred/early_exit/claim_paid` across `tests/` = 0). This opens a leveraged position, has a whale bet the same side to push it into profit, closes betting so the settlement force-close records the bettor residual as an outcome-contingent deferred claim (asserts it is **deferred, not refunded**), then resolves the winning side and asserts the claim pays from the bounded early-exit bucket and every claim row is consumed at settlement.

## Verification

Built the full chain + `consensus_sim_tests` target locally and ran both:

```
Running 2 test cases...
*** No errors detected
```

Observed values from the real run:
- supply case: `delta=26000 == expected_inflation=26000 (blocks=26)`
- early-exit case: position closes profitable (`cv=1232992 > obligation=1100000`), `bettor_received=132992` recorded as a deferred claim on side A (`n=1 total=132992`); trader balance unchanged at close (deferred), then rises by exactly `132992` after settlement (paid from the bucket).

Purely additive (273 lines, no existing code touched). Both cases append to `pm_lifecycle_suite` and auto-register with Boost — no CMake change; they run under `ctest`/CI like the other 51 cases.