### PR TITLE
build: default to Release, gate cat-parts to Windows, translate CMake comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,20 @@ endif()
 
 cmake_minimum_required(VERSION 3.16)
 
+# Default to a Release build when the caller doesn't specify one. Without this,
+# a bare `cmake ..` (or an IDE that doesn't pass -DCMAKE_BUILD_TYPE) configures
+# with empty optimization flags, producing an unoptimized node. Single-config
+# generators only; multi-config generators (MSVC, Ninja Multi-Config) pick the
+# type at build time and leave CMAKE_BUILD_TYPE empty by design.
+get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _is_multi_config AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+        "Choose the build type (Debug, Release, RelWithDebInfo, MinSizeRel)" FORCE)
+    message(STATUS "CMAKE_BUILD_TYPE not set; defaulting to Release")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
+endif()
+
 set(CHAIN_NAME "VIZ")
 
 
@@ -117,7 +131,7 @@ endif(CCACHE_FOUND)
 if(WIN32)
 
     message(STATUS "Configuring VIZ on WIN32")
-    set(PLATFORM_SPECIFIC_LIBS) # Păstrăm inițializarea pentru alte biblioteci
+    set(PLATFORM_SPECIFIC_LIBS) # Keep the initialization for other libraries
     set(DB_VERSION 60)
     set(BDB_STATIC_LIBS 1)
 
@@ -164,7 +178,7 @@ if(WIN32)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
     endif(FULL_STATIC_BUILD)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-    # bcrypt trebuie sa fie dupa toate librariile Boost statice
+    # bcrypt must come after all the static Boost libraries
     list(APPEND PLATFORM_SPECIFIC_LIBS bcrypt)
         # We remove the explicit addition of bcrypt to PLATFORM_SPECIFIC_LIBS, as it is now linked globally
     endif(MSVC)

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -24,16 +24,16 @@ else()
     )
 endif()
 
-# Target comun care depinde de fișierul generat
+# Common target that depends on the generated file
 add_custom_target(build_hardfork_hpp DEPENDS "${hardfork_hpp_out}")
 
-# Marchează fișierul ca generat
+# Mark the file as generated
 set_source_files_properties("${hardfork_hpp_out}" PROPERTIES GENERATED TRUE)
 
-# Include dir-ul binar
+# Include the binary include dir
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
-# Variabila folosită mai jos în add_library
+# Variable used below in add_library
 set(hardfork_hpp_file "${hardfork_hpp_out}")
 
 ## SORT .cpp by most likely to change / break compile

--- a/programs/build_helpers/CMakeLists.txt
+++ b/programs/build_helpers/CMakeLists.txt
@@ -1,7 +1,13 @@
-add_executable(cat-parts cat-parts.cpp)
-if(UNIX AND NOT APPLE)
-    set(rt_library rt)
-endif()
+# cat-parts concatenates hardfork.d/*.hf into hardfork.hpp. It is only invoked
+# on MSVC/MinGW (see libraries/chain/CMakeLists.txt); every other platform uses
+# cat_parts.py instead. Only build the binary where it is actually used so Linux
+# and macOS builds don't compile and link a tool they never run.
+if(MSVC OR MINGW)
+    add_executable(cat-parts cat-parts.cpp)
+    if(UNIX AND NOT APPLE)
+        set(rt_library rt)
+    endif()
 
-# we only actually need Boost, but link against FC for now so we don't duplicate it.
-target_link_libraries(cat-parts PRIVATE fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
+    # we only actually need Boost, but link against FC for now so we don't duplicate it.
+    target_link_libraries(cat-parts PRIVATE fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
+endif()


### PR DESCRIPTION
Three low-risk CMake cleanups from the repo review. No source logic touched.

## A. Default `CMAKE_BUILD_TYPE` to Release when unset
There was no default build type anywhere in the tree. A bare `cmake ..` — or an IDE that doesn't pass `-DCMAKE_BUILD_TYPE` — configured the project with **empty optimization flags**, producing an unoptimized node. Added a standard guard that defaults to `Release`.

- Guarded on `GENERATOR_IS_MULTI_CONFIG`, so multi-config generators (MSVC, Ninja Multi-Config) are left alone — they pick the config at build time and are meant to have an empty `CMAKE_BUILD_TYPE`.
- `build-linux.sh` and `build-mac.sh` always pass an explicit type, so their behavior is unchanged; this only affects hand/IDE configures that previously got no optimization.

## B. Build `cat-parts` only on MSVC/MinGW
`programs/build_helpers/CMakeLists.txt` compiled and linked the `cat-parts` hardfork concatenator on **every** platform, but `libraries/chain/CMakeLists.txt` only invokes it under `if(MSVC OR MINGW)` — Linux and macOS use `cat_parts.py` instead. So non-Windows builds were compiling+linking a tool they never run. Wrapped `add_executable(cat-parts …)` in the same `if(MSVC OR MINGW)` guard.

Verified the only `$<TARGET_FILE:cat-parts>` reference lives inside the matching MSVC/MinGW branch; the `else()` path uses Python and never touches the target, so non-Windows builds are unaffected.

## C. Translate leftover Romanian CMake comments
Five comments left over from a prior edit were in Romanian. Translated to English to match the rest of the files:
- `CMakeLists.txt` — `# Păstrăm inițializarea…`, `# bcrypt trebuie sa fie…`
- `libraries/chain/CMakeLists.txt` — `# Target comun…`, `# Marchează fișierul…`, `# Variabila folosită…`