### PR TITLE
build: collapse duplicated SHARED/STATIC add_library branches into VIZ_LIBRARY_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,16 @@ option(Boost_USE_STATIC_LIBS "Build with Boost static libraries usage" TRUE)
 
 option(BUILD_SHARED_LIBRARIES "Build shared libraries" FALSE)
 
+# Single source of truth for the library linkage type. Each library/plugin uses
+# add_library(<name> ${VIZ_LIBRARY_TYPE} ...) instead of duplicating the full
+# source list across if(BUILD_SHARED_LIBRARIES)/else() branches. Set at root
+# scope so it propagates into every add_subdirectory below.
+if(BUILD_SHARED_LIBRARIES)
+    set(VIZ_LIBRARY_TYPE SHARED)
+else()
+    set(VIZ_LIBRARY_TYPE STATIC)
+endif()
+
 option(BUILD_TESTNET "Build source for test network (ON OR OFF)" FALSE)
 message(STATUS "BUILD_TESTNET: ${BUILD_TESTNET}")
 if(BUILD_TESTNET)

--- a/libraries/api/CMakeLists.txt
+++ b/libraries/api/CMakeLists.txt
@@ -25,17 +25,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     paid_subscription_api_object.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -38,63 +38,7 @@ set(hardfork_hpp_file "${hardfork_hpp_out}")
 
 ## SORT .cpp by most likely to change / break compile
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_chain SHARED
-
-            # As database takes the longest to compile, start it first
-            database.cpp
-            fork_database.cpp
-
-            chain_evaluator.cpp
-            invite_evaluator.cpp
-
-            chain_objects.cpp
-            shared_authority.cpp
-            #        transaction_object.cpp
-            block_log.cpp
-            dlt_block_log.cpp
-            proposal_object.cpp
-            proposal_evaluator.cpp
-            database_proposal_object.cpp
-            chain_properties_evaluators.cpp
-            committee_evaluator.cpp
-            invite_evaluator.cpp
-            paid_subscription_evaluator.cpp
-
-            include/graphene/chain/account_object.hpp
-            include/graphene/chain/block_log.hpp
-            include/graphene/chain/dlt_block_log.hpp
-            include/graphene/chain/block_summary_object.hpp
-            include/graphene/chain/content_object.hpp
-            include/graphene/chain/proposal_object.hpp
-            include/graphene/chain/compound.hpp
-            include/graphene/chain/custom_operation_interpreter.hpp
-            include/graphene/chain/database.hpp
-            include/graphene/chain/database_exceptions.hpp
-            include/graphene/chain/db_with.hpp
-            include/graphene/chain/evaluator.hpp
-            include/graphene/chain/evaluator_registry.hpp
-            include/graphene/chain/fork_database.hpp
-            include/graphene/chain/generic_custom_operation_interpreter.hpp
-            include/graphene/chain/global_property_object.hpp
-            include/graphene/chain/immutable_chain_parameters.hpp
-            include/graphene/chain/index.hpp
-            include/graphene/chain/node_property_object.hpp
-            include/graphene/chain/operation_notification.hpp
-            include/graphene/chain/shared_authority.hpp
-            include/graphene/chain/shared_db_merkle.hpp
-            include/graphene/chain/chain_evaluator.hpp
-            include/graphene/chain/chain_object_types.hpp
-            include/graphene/chain/chain_objects.hpp
-            include/graphene/chain/transaction_object.hpp
-            include/graphene/chain/validator_objects.hpp
-            include/graphene/chain/committee_objects.hpp
-            include/graphene/chain/paid_subscription_objects.hpp
-
-            ${hardfork_hpp_file}
-            )
-else()
-    add_library(graphene_chain STATIC
+add_library(graphene_chain ${VIZ_LIBRARY_TYPE}
 
             # As database takes the longest to compile, start it first
             database.cpp
@@ -148,7 +92,6 @@ else()
 
             ${hardfork_hpp_file}
             )
-endif()
 
 add_dependencies(graphene_chain graphene_protocol graphene_utilities build_hardfork_hpp)
 target_link_libraries(graphene_chain graphene_protocol graphene_utilities fc chainbase appbase ${PATCH_MERGE_LIB})

--- a/libraries/network/CMakeLists.txt
+++ b/libraries/network/CMakeLists.txt
@@ -14,17 +14,10 @@ list(APPEND ${CURRENT_TARGET}_SOURCES
         dlt_p2p_node.cpp
         )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
             ${${CURRENT_TARGET}_HEADERS}
             ${${CURRENT_TARGET}_SOURCES}
             )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-            ${${CURRENT_TARGET}_HEADERS}
-            ${${CURRENT_TARGET}_SOURCES}
-            )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/libraries/protocol/CMakeLists.txt
+++ b/libraries/protocol/CMakeLists.txt
@@ -37,17 +37,10 @@ list(APPEND ${CURRENT_TARGET}_SOURCES
         version.cpp
         )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
             ${${CURRENT_TARGET}_HEADERS}
             ${${CURRENT_TARGET}_SOURCES}
             )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-            ${${CURRENT_TARGET}_HEADERS}
-            ${${CURRENT_TARGET}_SOURCES}
-            )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/libraries/time/CMakeLists.txt
+++ b/libraries/time/CMakeLists.txt
@@ -1,14 +1,8 @@
 file(GLOB HEADERS "include/graphene/time/*.hpp")
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_time SHARED
+add_library(graphene_time ${VIZ_LIBRARY_TYPE}
             time.cpp
             )
-else()
-    add_library(graphene_time STATIC
-            time.cpp
-            )
-endif()
 
 target_link_libraries(graphene_time fc)
 target_include_directories(graphene_time

--- a/libraries/utilities/CMakeLists.txt
+++ b/libraries/utilities/CMakeLists.txt
@@ -26,15 +26,9 @@ set(sources
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/git_revision.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/git_revision.cpp" @ONLY)
 list(APPEND sources "${CMAKE_CURRENT_BINARY_DIR}/git_revision.cpp")
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_utilities SHARED
+add_library(graphene_utilities ${VIZ_LIBRARY_TYPE}
             ${sources}
             ${HEADERS})
-else()
-    add_library(graphene_utilities STATIC
-            ${sources}
-            ${HEADERS})
-endif()
 target_link_libraries(graphene_utilities fc)
 target_include_directories(graphene_utilities
         PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/libraries/wallet/CMakeLists.txt
+++ b/libraries/wallet/CMakeLists.txt
@@ -19,17 +19,10 @@ list(APPEND ${CURRENT_TARGET}_SOURCES
         wallet.cpp
         )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
             ${${CURRENT_TARGET}_HEADERS}
             ${${CURRENT_TARGET}_SOURCES}
             )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-            ${${CURRENT_TARGET}_HEADERS}
-            ${${CURRENT_TARGET}_SOURCES}
-            )
-endif()
 # I don't know why graphene_app is required twice in the following line, I just know the linker breaks if it isn't.
 target_link_libraries(
         graphene_${CURRENT_TARGET}

--- a/plugins/account_by_key/CMakeLists.txt
+++ b/plugins/account_by_key/CMakeLists.txt
@@ -9,17 +9,10 @@ list(APPEND CURRENT_TARGET_SOURCES
         account_by_key_plugin.cpp
         )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
             ${CURRENT_TARGET_HEADERS}
             ${CURRENT_TARGET_SOURCES}
             )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-            ${CURRENT_TARGET_HEADERS}
-            ${CURRENT_TARGET_SOURCES}
-            )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/plugins/account_history/CMakeLists.txt
+++ b/plugins/account_history/CMakeLists.txt
@@ -9,17 +9,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     plugin.cpp
 )
 
-if (BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/block_info/CMakeLists.txt
+++ b/plugins/block_info/CMakeLists.txt
@@ -9,17 +9,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     plugin.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/chain/CMakeLists.txt
+++ b/plugins/chain/CMakeLists.txt
@@ -7,17 +7,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      plugin.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/committee_api/CMakeLists.txt
+++ b/plugins/committee_api/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
         committee_api.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/custom_protocol_api/CMakeLists.txt
+++ b/plugins/custom_protocol_api/CMakeLists.txt
@@ -11,17 +11,10 @@ list(APPEND CURRENT_TARGET_SOURCES
         custom_protocol_api_visitor.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/database_api/CMakeLists.txt
+++ b/plugins/database_api/CMakeLists.txt
@@ -17,17 +17,10 @@ list(APPEND ${CURRENT_TARGET}_SOURCES
      proposal_api_object.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${${CURRENT_TARGET}_HEADERS}
                 ${${CURRENT_TARGET}_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${${CURRENT_TARGET}_HEADERS}
-                ${${CURRENT_TARGET}_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/plugins/invite_api/CMakeLists.txt
+++ b/plugins/invite_api/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
         invite_api.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/json_rpc/CMakeLists.txt
+++ b/plugins/json_rpc/CMakeLists.txt
@@ -9,17 +9,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      plugin.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/plugins/network_broadcast_api/CMakeLists.txt
+++ b/plugins/network_broadcast_api/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      network_broadcast_api.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/plugins/operation_history/CMakeLists.txt
+++ b/plugins/operation_history/CMakeLists.txt
@@ -11,17 +11,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     applied_operation.cpp
 )
 
-if (BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/p2p/CMakeLists.txt
+++ b/plugins/p2p/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      p2p_plugin.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/paid_subscription_api/CMakeLists.txt
+++ b/plugins/paid_subscription_api/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
         paid_subscription_api.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/raw_block/CMakeLists.txt
+++ b/plugins/raw_block/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     plugin.cpp
 )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/snapshot/CMakeLists.txt
+++ b/plugins/snapshot/CMakeLists.txt
@@ -10,17 +10,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     plugin.cpp
 )
 
-if (BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/validator/CMakeLists.txt
+++ b/plugins/validator/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      validator.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/plugins/validator_api/CMakeLists.txt
+++ b/plugins/validator_api/CMakeLists.txt
@@ -9,17 +9,10 @@ list(APPEND CURRENT_TARGET_SOURCES
     plugin.cpp
 )
 
-if (BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
         ${CURRENT_TARGET_HEADERS}
         ${CURRENT_TARGET_SOURCES}
     )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-        ${CURRENT_TARGET_HEADERS}
-        ${CURRENT_TARGET_SOURCES}
-    )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 

--- a/plugins/validator_guard/CMakeLists.txt
+++ b/plugins/validator_guard/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      validator_guard.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
 set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})

--- a/plugins/webserver/CMakeLists.txt
+++ b/plugins/webserver/CMakeLists.txt
@@ -8,17 +8,10 @@ list(APPEND CURRENT_TARGET_SOURCES
      webserver_plugin.cpp
      )
 
-if(BUILD_SHARED_LIBRARIES)
-    add_library(graphene_${CURRENT_TARGET} SHARED
+add_library(graphene_${CURRENT_TARGET} ${VIZ_LIBRARY_TYPE}
                 ${CURRENT_TARGET_HEADERS}
                 ${CURRENT_TARGET_SOURCES}
                 )
-else()
-    add_library(graphene_${CURRENT_TARGET} STATIC
-                ${CURRENT_TARGET_HEADERS}
-                ${CURRENT_TARGET_SOURCES}
-                )
-endif()
 
 
 add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})


### PR DESCRIPTION
Addresses the `BUILD_SHARED_LIBRARIES` duplication (F035 in the tech-debt audit). No source code touched.

## Problem
Every library and plugin `CMakeLists.txt` carried its full source + header list **twice** — once under `add_library(<name> SHARED ...)` and once under `add_library(<name> STATIC ...)`, wrapped in `if(BUILD_SHARED_LIBRARIES)/else()/endif()`. 26 files, ~identical lists duplicated per file. Every source added to a library had to be added in two places, which is a standing drift hazard.

## Why collapse rather than drop the option
The option is still live: `build-mac.sh` defaults `SHARED_LIBS=ON`, so macOS local dev builds actually exercise the SHARED path. Dropping shared support would break that. So this keeps the option and removes only the duplication.

## Change
- Add a single `VIZ_LIBRARY_TYPE` variable at root scope: `SHARED` when `BUILD_SHARED_LIBRARIES` is ON, `STATIC` otherwise.
- Replace each dual-branch block with one `add_library(<name> ${VIZ_LIBRARY_TYPE} ...)`.
- **Net −220 lines** across 27 files.

## Drift fix (bonus)
The duplication had already drifted in `libraries/chain/CMakeLists.txt`: the **SHARED** branch listed `invite_evaluator.cpp` twice and was **missing** `include/graphene/chain/invite_objects.hpp`, while the STATIC branch was correct. Collapsing onto the STATIC list fixes both — shared builds of the chain lib were previously missing a header from the target's file list.

## Verification
- **Set-equivalence:** for all 26 targets, the collapsed source/header set is byte-set-identical to the original **STATIC** branch. Since the default build, all Docker images, and CI all use `-DBUILD_SHARED_LIBRARIES=FALSE`, static-build behavior is provably unchanged.
- **Real cmake configure:** built a minimal reproduction covering both the explicit-source pattern (`chain`/`time`) and the `${CURRENT_TARGET_SOURCES}` plugin pattern. `BUILD_SHARED_LIBRARIES=OFF` → `STATIC_LIBRARY` targets; `=ON` → `SHARED_LIBRARY` targets — matching the previous `if/else` semantics. `graphene::<name>` ALIAS targets still resolve.

(Full end-to-end compile not run in my environment — no Boost dev libs / submodules available — but the transformation is a mechanical branch-collapse with configure-level validation and set-level equivalence to the shipping static path.)