### PR TITLE
perf: add opt-in precompiled headers for chain/protocol/wallet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,32 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
+# Precompiled headers (opt-in, default OFF). When ON, the heaviest libraries
+# (chain, protocol, wallet) precompile a curated set of stable third-party
+# headers (Boost.MultiIndex, FC reflection/serialization, std) once per target
+# instead of re-parsing them in every translation unit. See each library's
+# pch.hpp for the header list and rationale.
+#
+# Left OFF by default so it cannot affect existing/CI builds until a maintainer
+# opts in and measures. If ccache is in use, PCH only helps when ccache is told
+# not to hash the (large, stable) PCH timestamp: export
+#   CCACHE_SLOPPINESS=pch_defines,time_macros
+# before building, otherwise ccache conservatively disables its own cache for
+# PCH-using compilations and you lose the ccache win without gaining the PCH one.
+option(ENABLE_PCH "Enable precompiled headers for heavy libraries" OFF)
+if(ENABLE_PCH)
+    message(STATUS "ENABLE_PCH: ON (precompiling stable third-party headers for chain/protocol/wallet)")
+    if(CCACHE_FOUND AND NOT "$ENV{CCACHE_SLOPPINESS}" MATCHES "pch_defines")
+        message(WARNING
+            "ENABLE_PCH is ON and ccache is active, but CCACHE_SLOPPINESS does not "
+            "include pch_defines,time_macros. ccache will likely disable caching for "
+            "PCH-using compilations. Export "
+            "CCACHE_SLOPPINESS=pch_defines,time_macros before building.")
+    endif()
+else()
+    message(STATUS "ENABLE_PCH: OFF")
+endif()
+
 if(WIN32)
 
     message(STATUS "Configuring VIZ on WIN32")

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -154,6 +154,10 @@ add_dependencies(graphene_chain graphene_protocol graphene_utilities build_hardf
 target_link_libraries(graphene_chain graphene_protocol graphene_utilities fc chainbase appbase ${PATCH_MERGE_LIB})
 target_include_directories(graphene_chain PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 
+if(ENABLE_PCH)
+    target_precompile_headers(graphene_chain PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp")
+endif()
+
 if(WITH_COVERAGE)
     target_compile_options(graphene_chain PRIVATE --coverage)
     target_link_options(graphene_chain PUBLIC --coverage)

--- a/libraries/chain/pch.hpp
+++ b/libraries/chain/pch.hpp
@@ -1,0 +1,41 @@
+// Precompiled header for graphene_chain.
+//
+// Opt-in via -DENABLE_PCH=ON. Lists only *stable* third-party headers (Boost,
+// FC, C++ standard library) that are pulled in — directly or transitively — by
+// most translation units in this library. Project headers are intentionally
+// excluded: they change often, and putting a churning header in the PCH forces
+// a full-library rebuild on every edit, defeating the purpose.
+//
+// Chosen from an include-frequency scan of libraries/chain/*.{hpp,cpp}; the
+// dominant cost here is Boost.MultiIndex plus FC serialization/reflection.
+#pragma once
+
+// Boost.MultiIndex — the chainbase object indexes instantiate these heavily.
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+
+// Boost misc used across the library.
+#include <boost/interprocess/containers/flat_set.hpp>
+#include <boost/filesystem.hpp>
+
+// FC framework — serialization, reflection, exceptions, primitives.
+#include <fc/exception/exception.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/io/datastream.hpp>
+#include <fc/variant.hpp>
+#include <fc/uint128_t.hpp>
+#include <fc/filesystem.hpp>
+
+// C++ standard library.
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+#include <memory>

--- a/libraries/protocol/CMakeLists.txt
+++ b/libraries/protocol/CMakeLists.txt
@@ -56,6 +56,10 @@ target_link_libraries(graphene_${CURRENT_TARGET} fc)
 target_include_directories(graphene_${CURRENT_TARGET}
         PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
 
+if(ENABLE_PCH)
+    target_precompile_headers(graphene_${CURRENT_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp")
+endif()
+
 if(WITH_COVERAGE)
     target_compile_options(graphene_${CURRENT_TARGET} PRIVATE --coverage)
     target_link_options(graphene_${CURRENT_TARGET} PUBLIC --coverage)

--- a/libraries/protocol/pch.hpp
+++ b/libraries/protocol/pch.hpp
@@ -1,0 +1,28 @@
+// Precompiled header for graphene_protocol.
+//
+// Opt-in via -DENABLE_PCH=ON. See libraries/chain/pch.hpp for the rationale:
+// only stable third-party headers, no project headers. Selected from an
+// include-frequency scan of libraries/protocol/*.{hpp,cpp}; the dominant cost
+// here is FC reflection / static_variant plus the operation type machinery.
+#pragma once
+
+// FC framework — reflection, serialization, primitives, crypto.
+#include <fc/reflect/reflect.hpp>
+#include <fc/reflect/variant.hpp>
+#include <fc/static_variant.hpp>
+#include <fc/exception/exception.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/io/varint.hpp>
+#include <fc/string.hpp>
+#include <fc/time.hpp>
+#include <fc/optional.hpp>
+#include <fc/smart_ref_impl.hpp>
+#include <fc/utf8.hpp>
+#include <fc/bitutil.hpp>
+
+// C++ standard library.
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+#include <memory>

--- a/libraries/wallet/CMakeLists.txt
+++ b/libraries/wallet/CMakeLists.txt
@@ -50,6 +50,10 @@ target_link_libraries(
 )
 target_include_directories( graphene_${CURRENT_TARGET} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
+if(ENABLE_PCH)
+    target_precompile_headers(graphene_${CURRENT_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp")
+endif()
+
 if(MSVC)
     set_source_files_properties(wallet.cpp PROPERTIES COMPILE_FLAGS "/bigobj")
 endif(MSVC)

--- a/libraries/wallet/pch.hpp
+++ b/libraries/wallet/pch.hpp
@@ -1,0 +1,34 @@
+// Precompiled header for graphene_wallet.
+//
+// Opt-in via -DENABLE_PCH=ON. See libraries/chain/pch.hpp for the rationale:
+// only stable third-party headers, no project headers. Selected from an
+// include-frequency scan of libraries/wallet/*.{hpp,cpp}; the cost here is
+// Boost.MultiIndex, Boost.Range/algorithm, and FC's api/reflection headers.
+#pragma once
+
+// Boost.MultiIndex.
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+
+// Boost string / range algorithms used through the wallet.
+#include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <boost/lexical_cast.hpp>
+
+// FC framework.
+#include <fc/api.hpp>
+#include <fc/macros.hpp>
+#include <fc/exception/exception.hpp>
+#include <fc/crypto/base58.hpp>
+
+// C++ standard library.
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <map>
+#include <list>
+#include <sstream>
+#include <iostream>
+#include <iterator>


### PR DESCRIPTION
Adds precompiled-header (PCH) support for the three heaviest libraries, gated behind a new `ENABLE_PCH` option (default **OFF**). No source code touched.

## Motivation
`cmake_minimum_required` is already 3.16, which has native `target_precompile_headers`, but nothing used it. Every translation unit in `chain`, `protocol`, and `wallet` re-parsed the same large template-heavy third-party headers from scratch. An include-frequency scan of each library's sources shows the cost concentrated in:
- **chain** — Boost.MultiIndex containers (`multi_index_container`, `ordered_index`, `hashed_index`, `composite_key`) + FC serialization/reflection
- **protocol** — FC reflection / `static_variant` + the operation type machinery
- **wallet** — Boost.MultiIndex, Boost string/range algorithms, FC `api`/reflection

## What this does
- New `libraries/{chain,protocol,wallet}/pch.hpp`, each listing only **stable** third-party headers (Boost, FC, std). Project headers are deliberately excluded — a churning header in the PCH would force a full-library rebuild on every edit and defeat the purpose.
- `target_precompile_headers(<lib> PRIVATE pch.hpp)` in each library, wrapped in `if(ENABLE_PCH)`.
- New root `option(ENABLE_PCH ... OFF)`.

## Safety
- **Default OFF** — cannot affect existing builds, Docker images, or CI until a maintainer opts in.
- **ccache-aware**: PCH and ccache conflict unless ccache is told not to hash the PCH. When `ENABLE_PCH=ON`, ccache is active, and `CCACHE_SLOPPINESS` lacks `pch_defines,time_macros`, CMake emits a warning (otherwise ccache silently disables its cache for PCH TUs — you'd lose the ccache win without gaining the PCH one).

## Usage
```bash
cmake -S . -B build -DENABLE_PCH=ON
# if you use ccache:
export CCACHE_SLOPPINESS=pch_defines,time_macros
```

## Validation
I don't have Boost dev libs or the submodules in my environment, so a full tree build wasn't possible. What I did verify with real `cmake`:
- The `ENABLE_PCH` logic executes correctly: OFF prints a silent status line; ON prints status **and** the ccache warning only when `CCACHE_SLOPPINESS` is unset; ON + sloppiness is clean.
- The `target_precompile_headers` wiring itself was proven end-to-end on a standalone CMake project mimicking the same shape — 24 TUs sharing one heavy header set. Single-threaded build: **16.84s → 5.73s (2.9×)**, with a real `.pch` artifact produced. (std headers stand in for Boost there; Boost.MultiIndex + FC reflection parse costs are at least as high, so this is a conservative proxy — not a measurement of this repo's actual numbers.)

**Ask for the maintainer:** run a real before/after on a build box —
```bash
# baseline
cmake -S . -B b_off && time cmake --build b_off -j$(nproc)
# with PCH
CCACHE_SLOPPINESS=pch_defines,time_macros cmake -S . -B b_on -DENABLE_PCH=ON && time cmake --build b_on -j$(nproc)
```
and confirm the win holds on this codebase before considering flipping the default.