### PR TITLE
fix(pm): couple closed-market retention to the commit reveal deadline (validate bound)

### DIFF
--- a/libraries/protocol/include/graphene/protocol/chain_operations.hpp
+++ b/libraries/protocol/include/graphene/protocol/chain_operations.hpp
@@ -742,6 +742,18 @@ namespace graphene { namespace protocol {
                 FC_ASSERT(pm_commit_no_reveal_penalty_percent <= 10000, "pm_commit_no_reveal_penalty_percent out of range");
                 FC_ASSERT(pm_batch_epoch_blocks > 0, "pm_batch_epoch_blocks must be positive");
                 FC_ASSERT(pm_reveal_window_blocks > 0, "pm_reveal_window_blocks must be positive");
+                // A commit's reveal deadline can fall up to (batch_epoch + reveal_window) blocks
+                // after the commit (pm_commit_bet), and its escrow is only refunded/forfeited by the
+                // reveal-forfeit cron at that deadline. gc_market deletes commit rows unconditionally
+                // once a market has been finalized for pm_closed_market_retention_sec. Require the
+                // retention to strictly exceed the worst-case reveal deadline so a still-unrevealed
+                // commit can never be garbage-collected before its escrow is returned — makes the
+                // "commit is always cleared before GC" invariant hold by construction, not by the
+                // default parameter magnitudes (5 d vs ~11 min) alone.
+                FC_ASSERT(pm_closed_market_retention_sec
+                              > (uint64_t)(pm_batch_epoch_blocks + pm_reveal_window_blocks) * CHAIN_BLOCK_INTERVAL,
+                    "pm_closed_market_retention_sec must exceed the worst-case commit reveal deadline "
+                    "((pm_batch_epoch_blocks + pm_reveal_window_blocks) * CHAIN_BLOCK_INTERVAL)");
                 FC_ASSERT(pm_processing_cap_per_block > 0, "pm_processing_cap_per_block must be positive");
                 FC_ASSERT(pm_lazy_alloc_percent <= 10000, "pm_lazy_alloc_percent out of range");
                 FC_ASSERT(pm_lazy_max_total_alloc_percent <= 10000, "pm_lazy_max_total_alloc_percent out of range");


### PR DESCRIPTION
## Summary

Defensive hardening for the commit-reveal escrow path, found during a money-path re-audit of the dispute / commit-reveal / lazy-pool subsystems.

## The gap

A commit's reveal deadline can fall up to `(pm_batch_epoch_blocks + pm_reveal_window_blocks)` blocks after the commit (`pm_commit_bet`), and its escrow is only refunded/forfeited by the reveal-forfeit cron at that deadline. `gc_market` deletes `pm_commit` rows **unconditionally** once a market has been finalized for `pm_closed_market_retention_sec` — with no status-0 refund.

Today this is safe **purely by parameter magnitudes**: the reveal deadline is ~11 min worst case, vs. a 5-day retention default — three orders of magnitude of slack. But:

- Nothing in code enforces the ordering (`gc_market`'s commit drop is an unconditional backstop).
- `pm_closed_market_retention_sec` had **no lower bound** in `validate()`.

So a misconfigured median (retention set below the reveal window) combined with a sustained `pm_processing_cap_per_block` starvation could let a still-unrevealed commit be garbage-collected before its escrow is returned — stranding a bettor's stake. Not attacker-triggerable and can't happen under sane params, but it's an invariant resting on luck rather than construction.

## The fix

One `validate()` assert:

```cpp
FC_ASSERT(pm_closed_market_retention_sec
              > (uint64_t)(pm_batch_epoch_blocks + pm_reveal_window_blocks) * CHAIN_BLOCK_INTERVAL,
    "pm_closed_market_retention_sec must exceed the worst-case commit reveal deadline ...");
```

placed right after the existing `pm_batch_epoch_blocks > 0` / `pm_reveal_window_blocks > 0` asserts (both operands already validated positive). This makes "a commit is always cleared before its market is GC'd" hold **by construction**.

## Safety

- Defaults satisfy it with wide margin: `432000 > (20 + 200) * 3 = 660`.
- No testnet config overrides these three params; `CHAIN_BLOCK_INTERVAL = 3` in both configs.
- `CHAIN_BLOCK_INTERVAL` is already used elsewhere in this validate body (no new include).
- Header syntax-checks clean against the chain build flags. No behavioural change for any valid configuration.

## Scope note

This is the root-cause fix (bound the parameter). A belt-and-suspenders alternative would be to also make `gc_market` refund any lingering status-0 commit before dropping it; I left that out deliberately since it adds a balance mutation to the GC path to guard a case this bound already prevents. Happy to add it if you'd prefer defense-in-depth. Full observation is written up on #124.
