### PR TITLE
Resolve hostname seed nodes and trusted snapshot peers

### DIFF
--- a/plugins/p2p/p2p_plugin.cpp
+++ b/plugins/p2p/p2p_plugin.cpp
@@ -518,30 +518,44 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
         my->max_connections = options.at("p2p-max-connections").as<uint32_t>();
     }
 
-    // Seed nodes (support both old and new config names)
-    if (options.count("seed-node")) {
-        for (const auto& addr : options.at("seed-node").as<vector<string>>()) {
+    // Seed nodes (support both old and new config names).
+    // fc::resolve() expects a bare host, so "seed.example.com:2001" has to be split first:
+    // passing the whole "host:port" string always failed to resolve and the seed was dropped
+    // without a word, leaving the node with "connecting to 0 seed nodes" and no peers.
+    auto add_seed = [&](const std::string& addr) {
+        try {
+            my->seeds.push_back(fc::ip::endpoint::from_string(addr));
+            return;
+        } catch (...) {}
+
+        auto colon = addr.rfind(':');
+        if (colon != std::string::npos) {
+            const std::string host = addr.substr(0, colon);
+            uint16_t port = 0;
             try {
-                my->seeds.push_back(fc::ip::endpoint::from_string(addr));
+                const unsigned long parsed = std::stoul(addr.substr(colon + 1));
+                if (parsed > 0 && parsed <= 65535) port = static_cast<uint16_t>(parsed);
             } catch (...) {
+                port = 0;
+            }
+            if (port != 0 && !host.empty()) {
                 try {
-                    auto eps = fc::resolve(addr, 0);
-                    if (!eps.empty()) my->seeds.push_back(eps.front());
+                    auto eps = fc::resolve(host, port);
+                    if (!eps.empty()) {
+                        my->seeds.push_back(eps.front());
+                        return;
+                    }
                 } catch (...) {}
             }
         }
+        wlog("Seed node ${a} is neither an IP endpoint nor a resolvable host:port — skipped", ("a", addr));
+    };
+
+    if (options.count("seed-node")) {
+        for (const auto& addr : options.at("seed-node").as<vector<string>>()) add_seed(addr);
     }
     if (options.count("p2p-seed-node")) {
-        for (const auto& addr : options.at("p2p-seed-node").as<vector<string>>()) {
-            try {
-                my->seeds.push_back(fc::ip::endpoint::from_string(addr));
-            } catch (...) {
-                try {
-                    auto eps = fc::resolve(addr, 0);
-                    if (!eps.empty()) my->seeds.push_back(eps.front());
-                } catch (...) {}
-            }
-        }
+        for (const auto& addr : options.at("p2p-seed-node").as<vector<string>>()) add_seed(addr);
     }
 
     // DLT config

--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -25,6 +25,7 @@
 #include <fc/compress/zlib.hpp>
 #include <fc/network/tcp_socket.hpp>
 #include <fc/network/ip.hpp>
+#include <fc/network/resolve.hpp>
 #include <fc/thread/thread.hpp>
 #include <fc/thread/mutex.hpp>
 #include <fc/thread/scoped_lock.hpp>
@@ -3910,6 +3911,30 @@ std::string snapshot_plugin::plugin_impl::download_snapshot_from_peers() {
 // Snapshot trusted-seeds diagnostic test
 // ============================================================================
 
+namespace {
+    /// Accepts both "1.2.3.4:8092" and "peer.example.com:8092".
+    fc::ip::endpoint resolve_peer_endpoint(const std::string& host_port) {
+        try {
+            return fc::ip::endpoint::from_string(host_port);
+        } catch (...) {}
+
+        auto colon = host_port.rfind(':');
+        FC_ASSERT(colon != std::string::npos, "Bad peer endpoint '${e}', expected host:port", ("e", host_port));
+        const std::string host = host_port.substr(0, colon);
+        unsigned long parsed = 0;
+        try {
+            parsed = std::stoul(host_port.substr(colon + 1));
+        } catch (...) {
+            FC_THROW("Bad port in peer endpoint '${e}'", ("e", host_port));
+        }
+        FC_ASSERT(parsed > 0 && parsed <= 65535, "Bad port in peer endpoint '${e}'", ("e", host_port));
+        const uint16_t port = static_cast<uint16_t>(parsed);
+        auto eps = fc::resolve(host, port);
+        FC_ASSERT(!eps.empty(), "Cannot resolve peer host '${h}'", ("h", host));
+        return eps.front();
+    }
+}
+
 void snapshot_plugin::plugin_impl::test_all_trusted_peers() {
     const size_t n_peers = trusted_snapshot_peers.size();
     std::cerr << "\n[test-trusted-seeds] Testing " << n_peers << " trusted peer(s)...\n";
@@ -3937,7 +3962,10 @@ void snapshot_plugin::plugin_impl::test_all_trusted_peers() {
 
         try {
             fc::tcp_socket sock;
-            auto ep = fc::ip::endpoint::from_string(peer_str);
+            // The real sync path (asio_tcp_socket::connect_to_endpoint) resolves DNS, so a
+            // host:port peer works there — but this diagnostic used to parse the endpoint as a
+            // literal IP only and reported every hostname from the docs as ERROR.
+            auto ep = resolve_peer_endpoint(peer_str);
 
             // --- 1. Measure TCP connect time ---
             auto t_connect_start = fc::time_point::now();


### PR DESCRIPTION
## Problem

`fc::resolve()` takes a bare host, but the p2p seed parsing (and the
`--test-trusted-seeds` probe) passed it the whole `host:port` string. Resolution
therefore always failed, and the failure was swallowed by `catch (...) {}`.

Consequence for anyone following our own documentation: every seed written as a
hostname is discarded. The shipped `share/vizd/config/config_witness.ini`
template and the examples in `docs/node/{getting-started,configuration,snapshot,validator-node}.md`
all use `seed3.viz.world:2001`, so a node started from them comes up with

```
DLT P2P node started, connecting to 0 seed nodes
Sync isolation: no active peers
```

The same string handling made `--test-trusted-seeds` report perfectly good
hostname peers as `ERROR` ("error converting std::string to IP endpoint"), even
though the real sync path resolves them (`asio_tcp_socket::connect_to_endpoint`).

## Verified on the current public build

`vizblockchain/vizd:latest`, empty data dir, config straight from the docs:

| seeds in config | result |
| --- | --- |
| `seed3.viz.world:2001`, `rpc.viz.cx:2001` | snapshot loaded (block 82657200), then `connecting to 0 seed nodes` → sync isolation |
| `175.110.112.214:2001`, `178.156.251.126:2001` | connected, blocks applied live (head 82658245+) |

`--test-trusted-seeds`: `ERROR` for both hostname peers, `REACHABLE connect=0ms
latency=3ms speed=22103KB/s` for the same peers written as IPs.

## Change

Split host and port before resolving, in both places; reject out-of-range
ports; log a warning instead of dropping a seed without a trace.

Non-consensus: config parsing and a diagnostic path only. Both touched TUs pass
`-fsyntax-only` on this branch.